### PR TITLE
Fix [JBJCA-915] Activation of connector 1.5 archive doesn't happen, when ironjacamar.xml doesn't contain class-names

### DIFF
--- a/deployers/src/main/java/org/jboss/jca/deployers/fungal/RADeployer.java
+++ b/deployers/src/main/java/org/jboss/jca/deployers/fungal/RADeployer.java
@@ -279,6 +279,10 @@ public final class RADeployer extends AbstractFungalRADeployer implements Deploy
                   if (raMcfClasses.contains(clz))
                      return true;
                }
+               if (raMcfClasses.size() == 1 && ijmd.getConnectionDefinitions().size() == 1)
+               {
+                  return true;
+               }
             }
 
             if (ijmd.getAdminObjects() != null)
@@ -289,6 +293,10 @@ public final class RADeployer extends AbstractFungalRADeployer implements Deploy
 
                   if (raAoClasses.contains(clz))
                      return true;
+               }
+               if (raAoClasses.size() == 1 && ijmd.getAdminObjects().size() == 1)
+               {
+                  return true;
                }
             }
          }

--- a/deployers/src/test/java/org/jboss/jca/deployers/test/unit/connector15/SimpleActivationWithIJDefaultClassNamesTestCase.java
+++ b/deployers/src/test/java/org/jboss/jca/deployers/test/unit/connector15/SimpleActivationWithIJDefaultClassNamesTestCase.java
@@ -31,7 +31,6 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -44,7 +43,6 @@ import org.junit.runner.RunWith;
  *
  */
 @RunWith(Arquillian.class)
-@Ignore("JBJCA-915")
 public class SimpleActivationWithIJDefaultClassNamesTestCase extends Activation15TestBase
 {
 


### PR DESCRIPTION
Could you please check the fix for JBJCA-915?

The fix will check activation in RADeployer.checkActivation() method in case of only one MCF or only one AO

The fix affects IJ only, for AS 7, I think we need the similar fix too.  
