### PR TITLE
fix mbean parse with nest element

### DIFF
--- a/as/src/main/java/org/jboss/jca/as/converters/AbstractParser.java
+++ b/as/src/main/java/org/jboss/jca/as/converters/AbstractParser.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
+import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
@@ -209,6 +210,42 @@ public abstract class AbstractParser
       }
 
       return longValue;
+   }
+   
+   /**
+    * convert an xml element in String value but ignore nest element
+    *
+    * @param reader the StAX reader
+    * @return the string representing element
+    * @throws XMLStreamException StAX exception
+    */
+   protected String elementAsStringNoNest(XMLStreamReader reader) throws XMLStreamException
+   {
+      if (reader.getEventType() != XMLStreamConstants.START_ELEMENT)
+      {
+         throw new XMLStreamException("parser must be on START_ELEMENT to read next text", reader.getLocation());
+      }
+      int eventType = reader.next();
+      StringBuilder content = new StringBuilder();
+      while (eventType != XMLStreamConstants.END_ELEMENT)
+      {
+         if (eventType == XMLStreamConstants.CHARACTERS || eventType == XMLStreamConstants.CDATA
+               || eventType == XMLStreamConstants.SPACE || eventType == XMLStreamConstants.ENTITY_REFERENCE)
+         {
+            content.append(reader.getText());
+         }
+         else if (eventType == XMLStreamConstants.PROCESSING_INSTRUCTION || eventType == XMLStreamConstants.COMMENT
+               || eventType == XMLStreamConstants.END_DOCUMENT || eventType == XMLStreamConstants.START_ELEMENT)
+         {
+            // skipping
+         }
+         else
+         {
+            throw new XMLStreamException("Unexpected event type " + eventType, reader.getLocation());
+         }
+         eventType = reader.next();
+      }
+      return content.toString();
    }
 
    /**

--- a/as/src/main/java/org/jboss/jca/as/converters/LegacyCfParser.java
+++ b/as/src/main/java/org/jboss/jca/as/converters/LegacyCfParser.java
@@ -596,7 +596,9 @@ public class LegacyCfParser extends AbstractParser
                switch (Mbean.Tag.forName(reader.getLocalName()))
                {
                   case ATTRIBUTE : {
-                     attributes.put(attributeAsString(reader, "name"), elementAsString(reader));
+                     String attrName = attributeAsString(reader, "name");
+                     String mbeanText = elementAsStringNoNest(reader);
+                     attributes.put(attrName, mbeanText);
                      break;
                   }
                   case DEPENDS : {


### PR DESCRIPTION
In asapxcess-jb3.2-ds.xml:
         <attribute name="MetadataURL">file:<add_properties_folder_path_here/></attribute>

before it is defined mbean as ANY in DTD.

We ignore nest element in "attribute" element.
