### PR TITLE
Excludes the java files from ironjacamar-deploys-common.jar when making the jar

### DIFF
--- a/deployers/build.xml
+++ b/deployers/build.xml
@@ -107,7 +107,7 @@
          indexMetaInf="true"
          update="true"
          level="9"
-         excludes="**/fungal/**">
+         excludes="**/fungal/**,**/*.java">
       <manifest>
         <attribute name="Implementation-Title" value="IronJacamar Deployers - Common"/>
         <attribute name="Implementation-Version" value="${version}"/>


### PR DESCRIPTION
It is good to exclude the java source file from the binary jar.
