### PR TITLE
[JBJCA-1075] ironjacamar-deployers-common.jar contains source files

### DIFF
--- a/deployers/build.xml
+++ b/deployers/build.xml
@@ -89,7 +89,7 @@
          indexMetaInf="true"
          update="true"
          level="9"
-         excludes="**/fungal/**">
+         excludes="**/fungal/**,**/*.java">
       <manifest>
         <attribute name="Implementation-Title" value="IronJacamar Deployers - Common"/>
         <attribute name="Implementation-Version" value="${version}"/>


### PR DESCRIPTION
It is good to exclude the java source file from the binary jar.
