### PR TITLE
[JBJCA-1195] - Incorrect currentSize passed to CapacityDecrementer.shoul...

### DIFF
--- a/core/src/main/java/org/jboss/jca/core/connectionmanager/pool/mcp/SemaphoreConcurrentLinkedQueueManagedConnectionPool.java
+++ b/core/src/main/java/org/jboss/jca/core/connectionmanager/pool/mcp/SemaphoreConcurrentLinkedQueueManagedConnectionPool.java
@@ -937,7 +937,7 @@ public class SemaphoreConcurrentLinkedQueueManagedConnectionPool implements Mana
          ConnectionListenerWrapper clw = clwIter.next();
 
          destroy = decrementer.shouldDestroy(clw.getConnectionListener(),
-               timeout, cls.size() + checkedOutSize.get(),
+               timeout, poolSize.get(),
                poolConfiguration.getMinSize(), destroyed);
 
          if (destroy) 


### PR DESCRIPTION
...dDestroy() from SemaphoreConcurrentLinkedQueueManagedConnectionPool
