### PR TITLE
Use Message Patterns for Debug Logging

### DIFF
--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/local/LocalManagedConnectionFactory.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/local/LocalManagedConnectionFactory.java
@@ -402,12 +402,12 @@ public class LocalManagedConnectionFactory extends BaseWrapperManagedConnectionF
       {
          this.urlSelector = new URLSelector();
          this.urlSelector.init(urlsList);
-         log.debug("Default URLSelectorStrategy is being used : " + urlSelector);
+         log.debugf("Default URLSelectorStrategy is being used : %s", urlSelector);
       }
       else
       {
          this.urlSelector = initUrlSelectorClass(getUrlSelectorStrategyClassName(), urlsList);
-         log.debug("Customized URLSelectorStrategy is being used : " + urlSelector);
+         log.debugf("Customized URLSelectorStrategy is being used : %s", urlSelector);
       }
    }
 
@@ -612,7 +612,7 @@ public class LocalManagedConnectionFactory extends BaseWrapperManagedConnectionF
          driver = (Driver)clazz.newInstance();
 
          DriverManager.registerDriver(driver);
-         log.debug("Driver loaded and instance created:" + driver);
+         log.debugf("Driver loaded and instance created:%s", driver);
 
          driverCache.put(driverKey, driver);
       }

--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/xa/XAManagedConnectionFactory.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/xa/XAManagedConnectionFactory.java
@@ -222,12 +222,12 @@ public class XAManagedConnectionFactory extends BaseWrapperManagedConnectionFact
             {
                xadsSelector = new URLXASelector();
                xadsSelector.init(xaDataList);
-               log.debug("Default URLXASelectorStrategy is being used : " + xadsSelector);
+               log.debugf("Default URLXASelectorStrategy is being used : %s", xadsSelector);
             }
             else
             {
                xadsSelector = initUrlSelectorClass(getUrlSelectorStrategyClassName(), xaDataList);
-               log.debug("Customized URLXASelectorStrategy is being used : " + xadsSelector);
+               log.debugf("Customized URLXASelectorStrategy is being used : %s", xadsSelector);
             }
          }
       }

--- a/common/src/main/java/org/jboss/jca/common/metadata/common/AbstractParser.java
+++ b/common/src/main/java/org/jboss/jca/common/metadata/common/AbstractParser.java
@@ -906,7 +906,8 @@ public abstract class AbstractParser
             case END_ELEMENT : {
                if (ConnectionDefinition.Tag.forName(reader.getLocalName()) == ConnectionDefinition.Tag.VALIDATION)
                {
-                  return new ValidationImpl(validateOnMatch, backgroundValidation, backgroundValidationMillis, useFastFail);
+                  return new ValidationImpl(validateOnMatch, backgroundValidation, backgroundValidationMillis,
+                                            useFastFail);
                }
                else
                {

--- a/core/src/main/java/org/jboss/jca/core/connectionmanager/AbstractConnectionManager.java
+++ b/core/src/main/java/org/jboss/jca/core/connectionmanager/AbstractConnectionManager.java
@@ -283,7 +283,7 @@ public abstract class AbstractConnectionManager implements ConnectionManager
     */
    public synchronized void shutdown()
    {
-      getLogger().debug(jndiName + ": shutdown");
+      getLogger().debugf("%s: shutdown", jndiName);
       shutdown.set(true);
 
       if (pool != null)

--- a/core/src/main/java/org/jboss/jca/core/connectionmanager/listener/TxConnectionListener.java
+++ b/core/src/main/java/org/jboss/jca/core/connectionmanager/listener/TxConnectionListener.java
@@ -193,8 +193,8 @@ public class TxConnectionListener extends AbstractConnectionListener
          }
          catch (XAException e)
          {
-            log.debug("XAException happend during return for: " + getPool() != null ? getPool().getName() : "Unknown",
-                      e);
+            log.debugf(e, "XAException happend during return for: %s",
+                       getPool() != null ? getPool().getName() : "Unknown");
          }
       }
    }
@@ -484,7 +484,7 @@ public class TxConnectionListener extends AbstractConnectionListener
                            }
                            else
                            {
-                              log.debug("delist-success failed: " + this);
+                              log.debugf("delist-success failed: %s", this);
                               success = false;
                            }
                         }
@@ -506,7 +506,7 @@ public class TxConnectionListener extends AbstractConnectionListener
                            }
                            else
                            {
-                              log.debug("delist-fail failed: " + this);
+                              log.debugf("delist-fail failed: %s", this);
 
                               success = false;
                            }
@@ -737,7 +737,7 @@ public class TxConnectionListener extends AbstractConnectionListener
          else
          {
             local.rollback();
-            log.debug("Unfinished local transaction was rolled back." + this);
+            log.debugf("Unfinished local transaction was rolled back.%s", this);
          }
       }
    }

--- a/core/src/main/java/org/jboss/jca/core/connectionmanager/pool/AbstractPool.java
+++ b/core/src/main/java/org/jboss/jca/core/connectionmanager/pool/AbstractPool.java
@@ -385,7 +385,7 @@ public abstract class AbstractPool implements Pool
     */
    public synchronized void emptyManagedConnectionPool(ManagedConnectionPool pool)
    {
-      log.debug(poolName + ": emptyManagedConnectionPool(" + pool + ")");
+      log.debugf("%s: emptyManagedConnectionPool(%s)", poolName, pool);
 
       if (pool != null)
       {
@@ -445,7 +445,7 @@ public abstract class AbstractPool implements Pool
     */
    public synchronized void flush(FlushMode mode)
    {
-      log.debug(poolName + ": flush(" + mode + ")");
+      log.debugf("%s: flush(%s)", poolName, mode);
 
       Set<ManagedConnectionPool> clearMcpPools = new HashSet<ManagedConnectionPool>();
       int size = mcpPools.size();
@@ -797,7 +797,7 @@ public abstract class AbstractPool implements Pool
     */
    public synchronized void shutdown()
    {
-      log.debug(poolName + ": shutdown");
+      log.debugf("%s: shutdown", poolName);
       shutdown.set(true);
 
       Iterator<ManagedConnectionPool> it = mcpPools.values().iterator();
@@ -811,7 +811,7 @@ public abstract class AbstractPool implements Pool
          catch (Exception e)
          {
             // Should not happen
-            log.trace("MCP.shutdown: " + e.getMessage(), e);
+            log.tracef(e, "MCP.shutdown: %s", e.getMessage());
          }
       }
 
@@ -823,7 +823,7 @@ public abstract class AbstractPool implements Pool
     */
    public void prepareShutdown()
    {
-      log.debug(poolName + ": prepareShutdown");
+      log.debugf("%s: prepareShutdown", poolName);
       shutdown.set(true);
 
       flush(FlushMode.GRACEFULLY);
@@ -834,7 +834,7 @@ public abstract class AbstractPool implements Pool
     */
    public boolean cancelShutdown()
    {
-      log.debug(poolName + ": cancelShutdown");
+      log.debugf("%s: cancelShutdown", poolName);
 
       if (shutdown.get())
       {
@@ -890,8 +890,8 @@ public abstract class AbstractPool implements Pool
     */
    protected boolean internalTestConnection(ConnectionRequestInfo cri, Subject subject)
    {
-      log.debug(poolName + ": testConnection(" + cri + ", " + subject + ")");
-      log.debug(poolName + ":   Statistics=" + statistics);
+      log.debugf("%s: testConnection(%s, %s)", poolName, cri, subject);
+      log.debugf("%s:   Statistics=%s", poolName, statistics);
 
       boolean result = false;
       boolean kill = false;

--- a/core/src/main/java/org/jboss/jca/core/connectionmanager/pool/mcp/SemaphoreConcurrentLinkedQueueManagedConnectionPool.java
+++ b/core/src/main/java/org/jboss/jca/core/connectionmanager/pool/mcp/SemaphoreConcurrentLinkedQueueManagedConnectionPool.java
@@ -1364,7 +1364,7 @@ public class SemaphoreConcurrentLinkedQueueManagedConnectionPool implements Mana
             }
             catch (Throwable t) 
             {
-               log.debug("Exception destroying ManagedConnection " + clw.getConnectionListener(), t);
+               log.debugf(t, "Exception destroying ManagedConnection %s", clw.getConnectionListener());
             }
 
             mc.removeConnectionEventListener(clw.getConnectionListener());

--- a/core/src/main/java/org/jboss/jca/core/connectionmanager/pool/strategy/PoolBySubject.java
+++ b/core/src/main/java/org/jboss/jca/core/connectionmanager/pool/strategy/PoolBySubject.java
@@ -90,7 +90,7 @@ public class PoolBySubject extends AbstractPrefillPool
       }
       catch (Throwable t)
       {
-         log.debug("Error during testConnection: " + t.getMessage(), t); 
+         log.debugf(t, "Error during testConnection: %s", t.getMessage());
       }
 
       return false;

--- a/core/src/main/java/org/jboss/jca/core/connectionmanager/tx/TxConnectionManagerImpl.java
+++ b/core/src/main/java/org/jboss/jca/core/connectionmanager/tx/TxConnectionManagerImpl.java
@@ -464,7 +464,8 @@ public class TxConnectionManagerImpl extends AbstractConnectionManager implement
 
                if (lock == null)
                   rethrowAsSystemException("Unable to obtain lock with JCA lazy enlistment scenario", tx,
-                                           new SystemException("Unable to obtain lock with JCA lazy enlistment scenario"));
+                                           new SystemException(
+                                                            "Unable to obtain lock with JCA lazy enlistment scenario"));
 
                try
                {
@@ -657,7 +658,7 @@ public class TxConnectionManagerImpl extends AbstractConnectionManager implement
     
          if (xaResourceTimeout != 0)
          {
-            log.debug("XAResource transaction timeout cannot be set for local transactions: " + getJndiName());  
+            log.debugf("XAResource transaction timeout cannot be set for local transactions: %s", getJndiName());
          }
       }      
       else
@@ -750,7 +751,7 @@ public class TxConnectionManagerImpl extends AbstractConnectionManager implement
                }
                else
                {
-                  log.debug("XAResource does not support transaction timeout configuration: " + getJndiName());
+                  log.debugf("XAResource does not support transaction timeout configuration: %s", getJndiName());
                }
             }
             catch (XAException e)
@@ -865,7 +866,8 @@ public class TxConnectionManagerImpl extends AbstractConnectionManager implement
                   else
                   {
                      if (trace)
-                        log.tracef("Already an enlisted connection in the pool tracked by transaction=%s (new=%s)", existing, cl);
+                        log.tracef("Already an enlisted connection in the pool tracked by transaction=%s (new=%s)",
+                                   existing, cl);
 
                      if (cl.supportsLazyAssociation())
                      {

--- a/core/src/main/java/org/jboss/jca/core/rar/ActivationImpl.java
+++ b/core/src/main/java/org/jboss/jca/core/rar/ActivationImpl.java
@@ -144,7 +144,7 @@ public class ActivationImpl implements Activation
             }
             catch (Throwable t)
             {
-               log.debug("Ignoring: " + propertyName + " (" + propertyValue + ")", t);
+               log.debugf(t, "Ignoring: %s (%s)", propertyName, propertyValue);
             }
          }
       }

--- a/core/src/main/java/org/jboss/jca/core/rar/EndpointImpl.java
+++ b/core/src/main/java/org/jboss/jca/core/rar/EndpointImpl.java
@@ -157,7 +157,7 @@ public class EndpointImpl implements Endpoint
                   }
                   catch (Throwable t)
                   {
-                     log.debug("Unable to load bean validation group: " + group, t);
+                     log.debugf(t, "Unable to load bean validation group: %s", group);
                   }
                }
             }

--- a/core/src/main/java/org/jboss/jca/core/rar/SimpleResourceAdapterRepository.java
+++ b/core/src/main/java/org/jboss/jca/core/rar/SimpleResourceAdapterRepository.java
@@ -560,7 +560,7 @@ public class SimpleResourceAdapterRepository implements ResourceAdapterRepositor
          }
          catch (Throwable t)
          {
-            log.debug("Exception while loading id: " + id, t);
+            log.debugf(t, "Exception while loading id: %s", id);
          }
       }
 
@@ -587,7 +587,7 @@ public class SimpleResourceAdapterRepository implements ResourceAdapterRepositor
       }
       catch (Throwable t)
       {
-         log.debug("Exception while loading ra.xml: " + id, t);
+         log.debugf(t, "Exception while loading ra.xml: %s", id);
       }
 
       return false;
@@ -618,7 +618,7 @@ public class SimpleResourceAdapterRepository implements ResourceAdapterRepositor
       }
       catch (Throwable t)
       {
-         log.debug("Exception while loading ironjacamar.xml: " + id, t);
+         log.debugf(t, "Exception while loading ironjacamar.xml: %s", id);
       }
 
       return null;
@@ -644,7 +644,7 @@ public class SimpleResourceAdapterRepository implements ResourceAdapterRepositor
       }
       catch (Throwable t)
       {
-         log.debug("Exception while loading ra.xml: " + id, t);
+         log.debugf(t, "Exception while loading ra.xml: %s", id);
       }
 
       return "";
@@ -671,7 +671,7 @@ public class SimpleResourceAdapterRepository implements ResourceAdapterRepositor
       }
       catch (Throwable t)
       {
-         log.debug("Exception while loading ra.xml: " + id, t);
+         log.debugf(t, "Exception while loading ra.xml: %s", id);
       }
 
       return "";

--- a/core/src/main/java/org/jboss/jca/core/recovery/ConfigurableRecoveryPlugin.java
+++ b/core/src/main/java/org/jboss/jca/core/recovery/ConfigurableRecoveryPlugin.java
@@ -181,7 +181,7 @@ public class ConfigurableRecoveryPlugin implements RecoveryPlugin
                }
                catch (Throwable t)
                {
-                  log.debug("Error during connection " + closeMethod + "()", t);
+                  log.debugf(t, "Error during connection %s()", closeMethod);
                   throw new ResourceException(bundle.errorDuringConnectionClose(), t);
                }
             }

--- a/core/src/test/java/org/jboss/jca/core/connectionmanager/connections/InterleavingTestCase.java
+++ b/core/src/test/java/org/jboss/jca/core/connectionmanager/connections/InterleavingTestCase.java
@@ -44,7 +44,6 @@ import javax.resource.spi.ManagedConnectionFactory;
 import javax.resource.spi.TransactionSupport.TransactionSupportLevel;
 import javax.transaction.RollbackException;
 import javax.transaction.Status;
-import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 import javax.transaction.xa.XAException;
 

--- a/deployers/src/main/java/org/jboss/jca/deployers/DeployersBundle.java
+++ b/deployers/src/main/java/org/jboss/jca/deployers/DeployersBundle.java
@@ -159,7 +159,8 @@ public interface DeployersBundle
     * @param implClz The implementation class name
     * @return The value
     */
-   @Message(id = 20066, value = "Connection factory implementation (%s) doesn't implement connection factory interface (%s)")
+   @Message(id = 20066, value = "Connection factory implementation (%s) "
+         + "doesn't implement connection factory interface (%s)")
    public String invalidConnectionFactoryImplementationDueToInterface(String intClz, String implClz);
 
    /**

--- a/deployers/src/main/java/org/jboss/jca/deployers/common/AbstractResourceAdapterDeployer.java
+++ b/deployers/src/main/java/org/jboss/jca/deployers/common/AbstractResourceAdapterDeployer.java
@@ -1005,7 +1005,7 @@ public abstract class AbstractResourceAdapterDeployer
                         }
                         else
                         {
-                           log.debug("No activation: " + aoClz);
+                           log.debugf("No activation: %s", aoClz);
                         }
                      }
                   }
@@ -1859,7 +1859,7 @@ public abstract class AbstractResourceAdapterDeployer
                         }
                         else
                         {
-                           log.debug("No activation: " + mcfClz);
+                           log.debugf("No activation: %s", mcfClz);
                         }
                      }
                   }
@@ -1964,7 +1964,10 @@ public abstract class AbstractResourceAdapterDeployer
          }
          else
          {
-            log.debug("Activated: " + url.toExternalForm());
+            if (log.isDebugEnabled())
+            {
+               log.debug("Activated: " + url.toExternalForm());
+            }
          }
 
          Object[] cfObjs = cfs.size() > 0 ? cfs.toArray(new Object[cfs.size()]) : null;

--- a/deployers/src/main/java/org/jboss/jca/deployers/fungal/AbstractFungalDeployment.java
+++ b/deployers/src/main/java/org/jboss/jca/deployers/fungal/AbstractFungalDeployment.java
@@ -203,8 +203,10 @@ public abstract class AbstractFungalDeployment implements Deployment
    {
       if (activator)
       {
-         log.debug("Undeploying: " + deployment.toExternalForm());
-         
+         if (log.isDebugEnabled())
+         {
+            log.debug("Undeploying: " + deployment.toExternalForm());
+         }
          if (server != null && objectNames != null)
          {
             for (ObjectName on : objectNames)

--- a/deployers/src/main/java/org/jboss/jca/deployers/fungal/DriverRegistry.java
+++ b/deployers/src/main/java/org/jboss/jca/deployers/fungal/DriverRegistry.java
@@ -122,7 +122,7 @@ public class DriverRegistry
                }
                catch (Throwable t)
                {
-                  log.debug("Exception for driver: " + driver, t);
+                  log.debugf(t, "Exception for driver: %s", driver);
                }
                finally
                {

--- a/deployers/src/main/java/org/jboss/jca/deployers/fungal/DsXmlDeployer.java
+++ b/deployers/src/main/java/org/jboss/jca/deployers/fungal/DsXmlDeployer.java
@@ -184,8 +184,10 @@ public final class DsXmlDeployer extends AbstractDsDeployer implements Deployer
     */
    public synchronized Deployment deploy(URL url, Context context, ClassLoader parent) throws DeployException
    {
-      log.debug("Deploying: " + url.toExternalForm());
-
+      if (log.isDebugEnabled())
+      {
+         log.debug("Deploying: " + url.toExternalForm());
+      }
       ClassLoader oldTCCL = SecurityActions.getThreadContextClassLoader();
       InputStream is = null;
       try

--- a/deployers/src/main/java/org/jboss/jca/deployers/fungal/DsXmlDeployment.java
+++ b/deployers/src/main/java/org/jboss/jca/deployers/fungal/DsXmlDeployment.java
@@ -176,8 +176,10 @@ public class DsXmlDeployment implements Deployment
     */
    public void stop()
    {
-      log.debug("Undeploying: " + deployment.toExternalForm());
-
+      if (log.isDebugEnabled())
+      {
+         log.debug("Undeploying: " + deployment.toExternalForm());
+      }
       if (objectNames != null && mbeanServer != null)
       {
          for (ObjectName on : objectNames)

--- a/deployers/src/main/java/org/jboss/jca/deployers/fungal/RAActivator.java
+++ b/deployers/src/main/java/org/jboss/jca/deployers/fungal/RAActivator.java
@@ -274,7 +274,7 @@ public final class RAActivator extends AbstractFungalRADeployer implements Deplo
             }
             catch (Throwable t)
             {
-               log.debug("Ignoring: " + deployment);
+               log.debugf(t, "Ignoring: %s", deployment);
             }
          }
       }
@@ -457,8 +457,10 @@ public final class RAActivator extends AbstractFungalRADeployer implements Deplo
    private Deployment deploy(URL url, ClassLoader parent) throws DeployException
    {
 
-      log.debug("Deploying: " + url.toExternalForm());
-
+      if (log.isDebugEnabled())
+      {
+         log.debug("Deploying: " + url.toExternalForm());
+      }
       ClassLoader oldTCCL = SecurityActions.getThreadContextClassLoader();
       try
       {

--- a/deployers/src/main/java/org/jboss/jca/deployers/fungal/RADeployer.java
+++ b/deployers/src/main/java/org/jboss/jca/deployers/fungal/RADeployer.java
@@ -109,8 +109,10 @@ public final class RADeployer extends AbstractFungalRADeployer implements Deploy
    public synchronized com.github.fungal.spi.deployers.Deployment deploy(URL url, Context context, ClassLoader parent)
       throws DeployException
    {
-      log.debug("Deploying: " + url.toExternalForm());
-
+      if (log.isDebugEnabled())
+      {
+         log.debug("Deploying: " + url.toExternalForm());
+      }
       ClassLoader oldTCCL = SecurityActions.getThreadContextClassLoader();
       try
       {

--- a/deployers/src/main/java/org/jboss/jca/deployers/fungal/RaXmlDeployer.java
+++ b/deployers/src/main/java/org/jboss/jca/deployers/fungal/RaXmlDeployer.java
@@ -161,8 +161,10 @@ public final class RaXmlDeployer extends AbstractFungalRADeployer
    @Override
    public synchronized Deployment deploy(URL url, Context context, ClassLoader parent) throws DeployException
    {
-      log.debug("Deploying: " + url.toExternalForm());
-
+      if (log.isDebugEnabled())
+      {
+         log.debug("Deploying: " + url.toExternalForm());
+      }
       ClassLoader oldTCCL = SecurityActions.getThreadContextClassLoader();
       InputStream is = null;
       try

--- a/deployers/src/test/java/org/jboss/jca/test/deployers/spec/rars/BaseManagedConnectionFactory.java
+++ b/deployers/src/test/java/org/jboss/jca/test/deployers/spec/rars/BaseManagedConnectionFactory.java
@@ -168,7 +168,7 @@ public class BaseManagedConnectionFactory implements ManagedConnectionFactory, R
     */
    public void setResourceAdapter(ResourceAdapter ra)
    {
-      log.debug("call setResourceAdapter(" + ra + ")");
+      log.debugf("call setResourceAdapter(%s)", ra);
       this.ra = ra;
    }
 

--- a/validator/src/test/java/org/jboss/jca/validator/rules/base/BaseManagedConnectionFactory.java
+++ b/validator/src/test/java/org/jboss/jca/validator/rules/base/BaseManagedConnectionFactory.java
@@ -167,7 +167,7 @@ public class BaseManagedConnectionFactory implements ManagedConnectionFactory, R
     */
    public void setResourceAdapter(ResourceAdapter ra)
    {
-      log.debug("call setResourceAdapter(" + ra + ")");
+      log.debugf("call setResourceAdapter(%s)", ra);
       this.ra = ra;
    }
 

--- a/web/src/main/java/org/jboss/jca/web/JNDIViewer.java
+++ b/web/src/main/java/org/jboss/jca/web/JNDIViewer.java
@@ -154,7 +154,7 @@ public class JNDIViewer
             }
             catch (Throwable t)
             {
-               log.debug("Invalid LinkRef for: " + name, t);
+               log.debugf(t, "Invalid LinkRef for: %s", name);
                buffer.append("invalid]");
             }
          }

--- a/web/src/main/java/org/jboss/jca/web/WARDeployer.java
+++ b/web/src/main/java/org/jboss/jca/web/WARDeployer.java
@@ -43,7 +43,6 @@ import org.eclipse.jetty.webapp.WebAppContext;
 public class WARDeployer implements Deployer
 {
    private static Logger log = Logger.getLogger(WARDeployer.class);
-   private static boolean trace = log.isTraceEnabled();
 
    private WebServer webServer;
        
@@ -97,8 +96,10 @@ public class WARDeployer implements Deployer
     */
    public synchronized Deployment deploy(URL url, Context context, ClassLoader parent) throws DeployException
    {
-      log.debug("Deploying: " + url.toExternalForm());
-
+      if (log.isDebugEnabled())
+      {
+         log.debug("Deploying: " + url.toExternalForm());
+      }
       try
       {
          String path = url.toExternalForm();
@@ -164,8 +165,8 @@ public class WARDeployer implements Deployer
          if (!tmpDeployment.mkdirs())
             throw new IOException("Unable to create " + tmpDeployment);
 
-         log.debug("ContextPath=" + contextPath);
-         log.debug("TmpPath=" + tmpPath);
+         log.debugf("ContextPath=%s", contextPath);
+         log.debugf("TmpPath=%s", tmpPath);
 
          WebAppContext webapp = new WebAppContext();
          webapp.setContextPath(contextPath);

--- a/web/src/main/java/org/jboss/jca/web/WARDeployment.java
+++ b/web/src/main/java/org/jboss/jca/web/WARDeployment.java
@@ -92,8 +92,10 @@ public class WARDeployment implements Deployment
     */
    public void destroy()
    {
-      log.debug("Undeploying: " + archive.toExternalForm());
-
+      if (log.isDebugEnabled())
+      {
+         log.debug("Undeploying: " + archive.toExternalForm());
+      }
       if (handler != null)
       {
          try


### PR DESCRIPTION
There are several places where IronJacamar uses string concatenation
for debug messages resulting in unnecessary allocation when debug
logging is not on.
- use message patterns for debug logging
- if additional method calls are made for debug message arguments put
  debug statements in if blocks

Issue: JBJCA-1227
https://issues.jboss.org/browse/JBJCA-1227
