### PR TITLE
Document Checkstyle Use

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Contributing
 
 * Write a blog about IronJacamar
 * Create a tutorial for IronJacamar
-* Help expand the [user guide](http://www.ironjacamar.org/doc/userguide/1.1/en-US/html/index.html)
+* Help expand the [user guide](http://www.ironjacamar.org/doc/userguide/1.2/en-US/html/index.html)
 * Answer questions and share ideas on the [IRC channel](http://webchat.freenode.net/?channels=ironjacamar)
 * Test [releases](http://www.ironjacamar.org/download.html)
 * Review [pull requests](http://github.com/ironjacamar/ironjacamar/pulls)

--- a/doc/developerguide/en-US/modules/building.xml
+++ b/doc/developerguide/en-US/modules/building.xml
@@ -152,6 +152,10 @@ ant &lt;target&gt;
         <para>Builds the JAR archives in the distribution and runs all the test cases.</para>
       </listitem>
       <listitem>
+        <para>checkstyle</para>
+        <para>Runs checkstyle, do this before committing your changes.</para>
+      </listitem>
+      <listitem>
         <para>module-test</para>
         <para>Builds the JAR archives in the distribution and runs all the test cases for the specified
         module (<code>-Dmodule=&lt;modulename&gt;</code>).</para>


### PR DESCRIPTION
Update the project documentation to mention that people should run
checkstyle.
- Add checkstyle to the list of documented targets
- Fix documentation link to point to the correct version
