### PR TITLE
[BZ1100839] :  (6.4.0) Intermittent fail of some datasource tests on IBM JDK 1.6 after attempt to load mysql driver for h2 datasource

### DIFF
--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/local/LocalManagedConnectionFactory.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/local/LocalManagedConnectionFactory.java
@@ -642,8 +642,9 @@ public class LocalManagedConnectionFactory extends BaseWrapperManagedConnectionF
          // Load class to trigger static initialization of the driver
          Class<?> clazz = Class.forName(driverClass, true, getClassLoaderPlugin().getClassLoader());
 
-         if (isDriverLoadedForURL(url))
-            return driver;
+        if (!isIbm16()) // BZ1100839
+            if (isDriverLoadedForURL(url))
+                return driver;
 
          driver = (Driver)clazz.newInstance();
 
@@ -660,6 +661,21 @@ public class LocalManagedConnectionFactory extends BaseWrapperManagedConnectionF
       return driver;
    }
 
+   // Added to bypass the IBM JDK 1.6 driverManager.getDriver() uncaught 
+   // exception (BZ1100839)
+   private boolean isIbm16()
+   {   
+       try{
+           String javaVersion = System.getProperty("java.version");
+           String javaHome = System.getenv("JAVA_HOME");
+           boolean isIbm16 = javaHome.contains("IBM") && javaVersion.contains("1.6");
+           
+           return isIbm16;
+       }catch(Exception e){
+           return false;
+       }
+   }
+   
    private boolean isDriverLoadedForURL(String url)
    {
       boolean trace = log.isTraceEnabled();


### PR DESCRIPTION
[BZ1100839] : https://bugzilla.redhat.com/show_bug.cgi?id=1100839
No upstream required.
