### PR TITLE
JBJCA-1248: XATransaction resource adapters should use a security domain...

### DIFF
--- a/as/src/main/java/org/jboss/jca/as/rarinfo/Main.java
+++ b/as/src/main/java/org/jboss/jca/as/rarinfo/Main.java
@@ -513,7 +513,7 @@ public class Main
                if (transSupport.equals(TransactionSupportEnum.XATransaction))
                {
                   pool = xaPoolImpl;
-                  Recovery recovery = new Recovery(new CredentialImpl("user", "password", null), null, false);
+                  Recovery recovery = new Recovery(new CredentialImpl(null, null, "domain"), null, false);
                   connImpl = new ConnectionDefinitionImpl(configProperty, mcfClassName, "java:jboss/eis/" + poolName,
                                                           poolName, Defaults.ENABLED, Defaults.USE_JAVA_CONTEXT,
                                                           Defaults.USE_CCM, Defaults.SHARABLE, Defaults.ENLISTMENT,


### PR DESCRIPTION
... for recovery