### PR TITLE
Handle both conns == null and conns.isEmpty() equally in ccm impl unreg

### DIFF
--- a/core/src/main/java/org/jboss/jca/core/connectionmanager/ccm/CachedConnectionManagerImpl.java
+++ b/core/src/main/java/org/jboss/jca/core/connectionmanager/ccm/CachedConnectionManagerImpl.java
@@ -330,7 +330,7 @@ public class CachedConnectionManagerImpl implements CachedConnectionManager
       CopyOnWriteArrayList<ConnectionRecord> conns = cmToConnectionsMap.get(cm);
 
       // Can happen if connections are "passed" between contexts
-      if (conns == null)
+      if (conns == null || conns.isEmpty())
          return; 
 
       // Note iterator of CopyOnWriteArrayList does not support remove method


### PR DESCRIPTION
Would a change like this be acceptable? Please note that I am far from understanding all consequences.

This change would make the "INFO IJ000311: Throwable from unregister connection: java.lang.IllegalStateException: Trying to return an unknown connection2!" messages disappear from the scenario mentioned in https://bugzilla.redhat.com/show_bug.cgi?id=1191580

