### PR TITLE
[JBJCA-1258] Remove driver cache

### DIFF
--- a/adapters/src/test/java/org/jboss/jca/adapters/jdbc/unit/H2DataSourceTestCase.java
+++ b/adapters/src/test/java/org/jboss/jca/adapters/jdbc/unit/H2DataSourceTestCase.java
@@ -100,5 +100,6 @@ public class H2DataSourceTestCase
       assertNotNull(ds);
       Connection c = ds.getConnection();
       assertNotNull(c);
+      c.close();
    }
 }

--- a/adapters/src/test/java/org/jboss/jca/adapters/jdbc/unit/H2DriverDataSourceTestCase.java
+++ b/adapters/src/test/java/org/jboss/jca/adapters/jdbc/unit/H2DriverDataSourceTestCase.java
@@ -100,5 +100,6 @@ public class H2DriverDataSourceTestCase
       assertNotNull(ds);
       Connection c = ds.getConnection();
       assertNotNull(c);
+      c.close();
    }
 }

--- a/adapters/src/test/java/org/jboss/jca/adapters/jdbc/unit/H2DriverTestCase.java
+++ b/adapters/src/test/java/org/jboss/jca/adapters/jdbc/unit/H2DriverTestCase.java
@@ -26,6 +26,7 @@ import org.jboss.jca.adapters.ArquillianJCATestUtils;
 import org.jboss.jca.embedded.dsl.InputStreamDescriptor;
 
 import java.sql.Connection;
+import java.sql.DriverManager;
 
 import javax.annotation.Resource;
 import javax.sql.DataSource;
@@ -100,5 +101,19 @@ public class H2DriverTestCase
       assertNotNull(ds);
       Connection c = ds.getConnection();
       assertNotNull(c);
+      c.close();
+   }
+
+   /**
+    * Tests that it is possible the call DriverManager.getConnection() returns a connection
+    *
+    * @exception Throwable Thrown if case of an error
+    */
+   @Test
+   public void testDriverManagerGetConnection() throws Throwable
+   {
+      Connection conn = DriverManager.getConnection("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", "sa", "sa");
+      assertNotNull(conn);
+      conn.close();
    }
 }

--- a/adapters/src/test/java/org/jboss/jca/adapters/jdbc/unit/H2DynamicDriverTestCase.java
+++ b/adapters/src/test/java/org/jboss/jca/adapters/jdbc/unit/H2DynamicDriverTestCase.java
@@ -99,5 +99,6 @@ public class H2DynamicDriverTestCase
       assertNotNull(ds);
       Connection c = ds.getConnection();
       assertNotNull(c);
+      c.close();
    }
 }

--- a/adapters/src/test/java/org/jboss/jca/adapters/jdbc/unit/H2ModuleTestCase.java
+++ b/adapters/src/test/java/org/jboss/jca/adapters/jdbc/unit/H2ModuleTestCase.java
@@ -99,5 +99,6 @@ public class H2ModuleTestCase
       assertNotNull(ds);
       Connection c = ds.getConnection();
       assertNotNull(c);
+      c.close();
    }
 }


### PR DESCRIPTION
[BZ-1157649] Multiple JDBC drivers versions - wrong driver is used

Bugzilla reference: https://bugzilla.redhat.com/show_bug.cgi?id=1157649

PR in 1.2 branch: https://github.com/ironjacamar/ironjacamar/pull/316

Should we use the same Jira for this, or create a new one?