### PR TITLE
BZ1230980 throw SQLException instead of log a warn message.

### DIFF
--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/extensions/oracle/OracleValidConnectionChecker.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/extensions/oracle/OracleValidConnectionChecker.java
@@ -69,8 +69,7 @@ public class OracleValidConnectionChecker implements ValidConnectionChecker, Ser
       }
       catch (Exception e)
       {
-         // What do we do here? Assume it is a misconfiguration
-         log.warn("Unexpected error in pingDatabase", e);
+         return new SQLException("pingDatabase failed", e);
       }
 
       // OK


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1230981
Since we handled SQLException in EAP 5.2 and future IJ 1.2 series
1.1 branch backport of partial upstream commit https://github.com/ironjacamar/ironjacamar/commit/8dcbab49cead26a8113371ef48c075bc16adb17b#diff-9f8b3b8570171393f37acc1c02391c28R72 from 1.2 branch 