### PR TITLE
JBJCA-1289 Move RpcDispatcher creation to protected method to allow customization by subclasses.

### DIFF
--- a/core/src/main/java/org/jboss/jca/core/workmanager/transport/remote/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/jboss/jca/core/workmanager/transport/remote/jgroups/JGroupsTransport.java
@@ -446,9 +446,23 @@ public class JGroupsTransport extends AbstractRemoteTransport<org.jgroups.Addres
     */
    public void startup() throws Throwable
    {
-      disp = new RpcDispatcher(channel, null, this, this);
+      disp = createRpcDispatcher();
 
-      disp.setMethodLookup(new MethodLookup()
+      if (clusterName == null)
+         clusterName = "jca";
+
+      channel.connect(clusterName);
+   }
+
+   /**
+    * Creates an rpc dispatcher used by this transport
+    * @return an rpc dispatcher
+    */
+   protected RpcDispatcher createRpcDispatcher()
+   {
+      RpcDispatcher dispatcher = new RpcDispatcher(channel, null, this, this);
+
+      dispatcher.setMethodLookup(new MethodLookup()
       {
          @Override
          public Method findMethod(short key)
@@ -456,11 +470,7 @@ public class JGroupsTransport extends AbstractRemoteTransport<org.jgroups.Addres
             return methods.get(key);
          }
       });
-
-      if (clusterName == null)
-         clusterName = "jca";
-
-      channel.connect(clusterName);
+      return dispatcher;
    }
 
    /**


### PR DESCRIPTION
https://issues.jboss.org/browse/JBJCA-1289
Needed for https://issues.jboss.org/browse/WFLY-5188

Since the response marshaller really ought to be configured before the channel is connected, I opted for a separate factory method (which can be overridden) rather than merely exposing the RpcDispatcher field as protected.

Also, this PR applies to the 1.2 branch.  I don't see this class in master.