### PR TITLE
[WFLY-2492] Use a PreferredClasses to store pre loaded extension classes

### DIFF
--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/BaseWrapperManagedConnectionFactory.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/BaseWrapperManagedConnectionFactory.java
@@ -37,6 +37,7 @@ import org.jboss.jca.adapters.jdbc.spi.reauth.ReauthPlugin;
 import org.jboss.jca.adapters.jdbc.statistics.JdbcStatisticsPlugin;
 import org.jboss.jca.adapters.jdbc.util.Injection;
 import org.jboss.jca.core.spi.statistics.Statistics;
+import org.jboss.jca.core.util.PreferredClasses;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -758,14 +759,22 @@ public abstract class BaseWrapperManagedConnectionFactory
       Class<?> clz = null;
       ClassLoader usedCl = null;
 
-      try
+      clz = PreferredClasses.getInstance().getClass(reauthPluginClassName);
+      if (clz == null)
       {
-         clz = Class.forName(reauthPluginClassName, true, getClassLoaderPlugin().getClassLoader());
-         usedCl = getClassLoaderPlugin().getClassLoader();
+         try
+         {
+            clz = Class.forName(reauthPluginClassName, true, getClassLoaderPlugin().getClassLoader());
+            usedCl = getClassLoaderPlugin().getClassLoader();
+         }
+         catch (ClassNotFoundException cnfe)
+         {
+            // Not found
+         }
       }
-      catch (ClassNotFoundException cnfe)
+      else
       {
-         // Not found
+         usedCl = SecurityActions.getClassLoader(clz);
       }
 
       if (clz == null)
@@ -893,14 +902,22 @@ public abstract class BaseWrapperManagedConnectionFactory
       Class<?> clz = null;
       ClassLoader usedCl = null;
 
-      try
+      clz = PreferredClasses.getInstance().getClass(connectionListenerClassName);
+      if (clz == null)
       {
-         clz = Class.forName(connectionListenerClassName, true, getClassLoaderPlugin().getClassLoader());
-         usedCl = getClassLoaderPlugin().getClassLoader();
+         try
+         {
+            clz = Class.forName(connectionListenerClassName, true, getClassLoaderPlugin().getClassLoader());
+            usedCl = getClassLoaderPlugin().getClassLoader();
+         }
+         catch (ClassNotFoundException cnfe)
+         {
+            // Not found
+         }
       }
-      catch (ClassNotFoundException cnfe)
+      else
       {
-         // Not found
+         usedCl = SecurityActions.getClassLoader(clz);
       }
 
       if (clz == null)
@@ -1158,13 +1175,17 @@ public abstract class BaseWrapperManagedConnectionFactory
          throw new IllegalArgumentException("Plugin isn't defined");
 
       Class<?> clz = null;
-      try
+      clz = PreferredClasses.getInstance().getClass(plugin);
+      if (clz == null)
       {
-         clz = Class.forName(plugin, true, getClassLoaderPlugin().getClassLoader());
-      }
-      catch (ClassNotFoundException cnfe)
-      {
-         // Not found
+         try
+         {
+            clz = Class.forName(plugin, true, getClassLoaderPlugin().getClassLoader());
+         }
+         catch (ClassNotFoundException cnfe)
+         {
+            // Not found
+         }
       }
 
       if (clz == null)

--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/local/LocalManagedConnectionFactory.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/local/LocalManagedConnectionFactory.java
@@ -26,6 +26,7 @@ import org.jboss.jca.adapters.jdbc.BaseWrapperManagedConnectionFactory;
 import org.jboss.jca.adapters.jdbc.classloading.TCClassLoaderPlugin;
 import org.jboss.jca.adapters.jdbc.spi.URLSelectorStrategy;
 import org.jboss.jca.adapters.jdbc.util.Injection;
+import org.jboss.jca.core.util.PreferredClasses;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -420,13 +421,17 @@ public class LocalManagedConnectionFactory extends BaseWrapperManagedConnectionF
       }
 
       Class<?> clz = null;
-      try
+      clz = PreferredClasses.getInstance().getClass(className);
+      if (clz == null)
       {
-         clz = Class.forName(className, true, getClassLoaderPlugin().getClassLoader());
-      }
-      catch (ClassNotFoundException cnfe)
-      {
-         // Not found
+         try
+         {
+            clz = Class.forName(className, true, getClassLoaderPlugin().getClassLoader());
+         }
+         catch (ClassNotFoundException cnfe)
+         {
+            // Not found
+         }
       }
 
       if (clz == null)

--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/xa/XAManagedConnectionFactory.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/xa/XAManagedConnectionFactory.java
@@ -27,6 +27,7 @@ import org.jboss.jca.adapters.jdbc.classloading.TCClassLoaderPlugin;
 import org.jboss.jca.adapters.jdbc.spi.URLXASelectorStrategy;
 import org.jboss.jca.adapters.jdbc.spi.XAData;
 import org.jboss.jca.adapters.jdbc.util.Injection;
+import org.jboss.jca.core.util.PreferredClasses;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -248,13 +249,17 @@ public class XAManagedConnectionFactory extends BaseWrapperManagedConnectionFact
       }
 
       Class<?> clz = null;
-      try
+      clz = PreferredClasses.getInstance().getClass(className);
+      if (clz == null)
       {
-         clz = Class.forName(className, true, getClassLoaderPlugin().getClassLoader());
-      }
-      catch (ClassNotFoundException cnfe)
-      {
-         // Not found
+         try
+         {
+            clz = Class.forName(className, true, getClassLoaderPlugin().getClassLoader());
+         }
+         catch (ClassNotFoundException cnfe)
+         {
+            // Not found
+         }          
       }
 
       if (clz == null)

--- a/core/src/main/java/org/jboss/jca/core/connectionmanager/pool/capacity/CapacityFactory.java
+++ b/core/src/main/java/org/jboss/jca/core/connectionmanager/pool/capacity/CapacityFactory.java
@@ -25,6 +25,7 @@ import org.jboss.jca.core.CoreLogger;
 import org.jboss.jca.core.connectionmanager.pool.api.CapacityDecrementer;
 import org.jboss.jca.core.connectionmanager.pool.api.CapacityIncrementer;
 import org.jboss.jca.core.util.Injection;
+import org.jboss.jca.core.util.PreferredClasses;
 
 import java.util.Map;
 
@@ -218,6 +219,19 @@ public class CapacityFactory
     */
    private static Object loadClass(String clz)
    {
+      try
+      {
+         Class<?> c = PreferredClasses.getInstance().getClass(clz);
+         if (c != null)
+         {
+            return c.newInstance(); 
+         }
+      }
+      catch (Throwable t)
+      {
+         log.tracef("Throwable while loading %s using registered preferred class: %s", clz, t.getMessage());
+      }
+
       try
       {
          Class<?> c = Class.forName(clz, true, SecurityActions.getClassLoader(CapacityFactory.class));

--- a/core/src/main/java/org/jboss/jca/core/util/PreferredClasses.java
+++ b/core/src/main/java/org/jboss/jca/core/util/PreferredClasses.java
@@ -1,0 +1,96 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2015, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.jca.core.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * PreferedClasses will try to use the Classes if they were loaded already.
+ *
+ * @author <a href="mailto:lin.gao@ironjacamar.org">Lin Gao</a>
+ */
+public final class PreferredClasses
+{ 
+
+   private static final PreferredClasses INSTANCE = new PreferredClasses();
+
+   /**
+    * Gets the singleton PreferredClasses instance.
+    * 
+    * @return the PreferredClasses instance.
+    */
+   public static synchronized PreferredClasses getInstance()
+   {
+      return INSTANCE;
+   }
+
+   /**
+    * Default private Constructor.
+    */
+   private PreferredClasses()
+   {
+      //nothing;
+   }
+
+   private Map<String, Class<?>> preferredCls = new HashMap<String, Class<?>>();
+
+   /**
+    * Registers a Class into preferred classes.
+    * 
+    * @param className the full-qualified class name for the Class to be registered.
+    * @param cls The Class which has been loaded already
+    * @return this PrefereedClasses instance for convenient.
+    */
+   public synchronized PreferredClasses registerClass(String className, Class<?> cls)
+   {
+      preferredCls.putIfAbsent(className, cls);
+      return this;
+   }
+
+   /**
+    * Unregisters a Class by it's className
+    * 
+    * @param className the full-qualified class name for the Class registered.
+    * @return this PrefereedClasses instance for convenient.
+    */
+   public synchronized PreferredClasses unRegisterClass(String className)
+   {
+      preferredCls.remove(className);
+      return this;
+   }
+
+   /**
+    * Gets Registered Class by the full-qualified class name.
+    * 
+    * @param className the full-qualified class name for the Class registered.
+    * @return The Preferred 
+    */
+   public synchronized Class<?> getClass(String className)
+   {
+      if (className == null || className.length() == 0)
+      {
+         return null;
+      }
+      return preferredCls.get(className);
+   }
+}


### PR DESCRIPTION
This is proposed changes for [WFLY-2492](https://issues.jboss.org/browse/WFLY-2492), related PR in wildfly is at: https://github.com/wildfly/wildfly/pull/7838

This proposed change contains a new Class called: `PreferredClasses` at: `core/src/main/java/org/jboss/jca/core/util/PreferredClasses.java`, which will be able to remember the loaded Classes with the full-qualified class name, when the extension classes need to be loaded in IJ, it will check whether the class has been loaded by WildFly already, if it has, then IJ will use the Class directly, otherwise, it will continue to use the current way to load the Class.

With this change, WildFly datasource/resouce adapter subsystem can register the loaded extension classes into IJ use this `PreferredClasses`. 