### PR TITLE
[JBJCA-1276] fix DsTestCase

### DIFF
--- a/rhq/src/test/java/org/jboss/jca/rhq/test/DsTestCase.java
+++ b/rhq/src/test/java/org/jboss/jca/rhq/test/DsTestCase.java
@@ -273,7 +273,7 @@ public class DsTestCase
       pool.flush(true);  // it flushes all connections from the pool.
       
       assertEquals(0, poolStatistics.getActiveCount());
-      assertEquals(0, poolStatistics.getCreatedCount());
+      assertEquals(1, poolStatistics.getCreatedCount());
       assertEquals(ds.getPoolConfiguration().getMaxSize(), poolStatistics.getAvailableCount());
       
       conn.close();


### PR DESCRIPTION
There is no reason to shut the MCP down if there is only one MCP, so createdCount isn't cleared