### PR TITLE
[#467] Recovery (outbound)

### DIFF
--- a/core/src/main/java/org/ironjacamar/core/api/deploymentrepository/AdminObject.java
+++ b/core/src/main/java/org/ironjacamar/core/api/deploymentrepository/AdminObject.java
@@ -62,14 +62,22 @@ public interface AdminObject
    public StatisticsPlugin getStatistics();
 
    /**
+    * Is the admin object active ?
+    * @return <code>true</code> if activated, <code>false</code> if not
+    */
+   public boolean isActivated();
+
+   /**
     * Activate the admin object
+    * @return <code>true</code> if activated, <code>false</code> if already activated
     * @exception Exception Thrown in case of an error
     */
-   public void activate() throws Exception;
+   public boolean activate() throws Exception;
 
    /**
     * Deactivate the admin object
+    * @return <code>true</code> if deactivated, <code>false</code> if already deactivated
     * @exception Exception Thrown in case of an error
     */
-   public void deactivate() throws Exception;
+   public boolean deactivate() throws Exception;
 }

--- a/core/src/main/java/org/ironjacamar/core/api/deploymentrepository/ConnectionFactory.java
+++ b/core/src/main/java/org/ironjacamar/core/api/deploymentrepository/ConnectionFactory.java
@@ -82,14 +82,22 @@ public interface ConnectionFactory
    public Recovery getRecovery();
 
    /**
+    * Is the connection factory active ?
+    * @return <code>true</code> if activated, <code>false</code> if not
+    */
+   public boolean isActivated();
+
+   /**
     * Activate the connection factory
+    * @return <code>true</code> if activated, <code>false</code> if already activated
     * @exception Exception Thrown in case of an error
     */
-   public void activate() throws Exception;
+   public boolean activate() throws Exception;
 
    /**
     * Deactivate the connection factory
+    * @return <code>true</code> if deactivated, <code>false</code> if already deactivated
     * @exception Exception Thrown in case of an error
     */
-   public void deactivate() throws Exception;
+   public boolean deactivate() throws Exception;
 }

--- a/core/src/main/java/org/ironjacamar/core/api/deploymentrepository/Deployment.java
+++ b/core/src/main/java/org/ironjacamar/core/api/deploymentrepository/Deployment.java
@@ -88,14 +88,22 @@ public interface Deployment
    public Collection<AdminObject> getAdminObjects();
 
    /**
+    * Is the deployment active ?
+    * @return <code>true</code> if activated, <code>false</code> if not
+    */
+   public boolean isActivated();
+
+   /**
     * Activate the deployment
+    * @return <code>true</code> if activated, <code>false</code> if already activated
     * @exception Exception Thrown in case of an error
     */
-   public void activate() throws Exception;
+   public boolean activate() throws Exception;
 
    /**
     * Deactivate the deployment
+    * @return <code>true</code> if deactivated, <code>false</code> if already deactivated
     * @exception Exception Thrown in case of an error
     */
-   public void deactivate() throws Exception;
+   public boolean deactivate() throws Exception;
 }

--- a/core/src/main/java/org/ironjacamar/core/api/deploymentrepository/Recovery.java
+++ b/core/src/main/java/org/ironjacamar/core/api/deploymentrepository/Recovery.java
@@ -21,10 +21,43 @@
 
 package org.ironjacamar.core.api.deploymentrepository;
 
+import java.util.Collection;
+
 /**
  * Recovery module
  * @author <a href="jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
  */
 public interface Recovery
 {
+   /**
+    * Get the class name of the recovery plugin used
+    * @return The value
+    */
+   public String getPluginClassName();
+   
+   /**
+    * Get the configuration properties used -- read-only
+    * @return The value
+    */
+   public Collection<ConfigProperty> getConfigProperties();
+
+   /**
+    * Is the recovery active ?
+    * @return <code>true</code> if activated, <code>false</code> if not
+    */
+   public boolean isActivated();
+
+   /**
+    * Activate the recovery
+    * @return <code>true</code> if activated, <code>false</code> if already activated
+    * @exception Exception Thrown in case of an error
+    */
+   public boolean activate() throws Exception;
+
+   /**
+    * Deactivate the recovery
+    * @return <code>true</code> if deactivated, <code>false</code> if already deactivated
+    * @exception Exception Thrown in case of an error
+    */
+   public boolean deactivate() throws Exception;
 }

--- a/core/src/main/java/org/ironjacamar/core/api/deploymentrepository/ResourceAdapter.java
+++ b/core/src/main/java/org/ironjacamar/core/api/deploymentrepository/ResourceAdapter.java
@@ -64,14 +64,22 @@ public interface ResourceAdapter
    public Recovery getRecovery();
 
    /**
+    * Is the resource adapter active ?
+    * @return <code>true</code> if activated, <code>false</code> if not
+    */
+   public boolean isActivated();
+
+   /**
     * Activate the resource adapter
+    * @return <code>true</code> if activated, <code>false</code> if already activated
     * @exception Exception Thrown in case of an error
     */
-   public void activate() throws Exception;
+   public boolean activate() throws Exception;
 
    /**
     * Deactivate the resource adapter
+    * @return <code>true</code> if deactivated, <code>false</code> if already deactivated
     * @exception Exception Thrown in case of an error
     */
-   public void deactivate() throws Exception;
+   public boolean deactivate() throws Exception;
 }

--- a/core/src/main/java/org/ironjacamar/core/deploymentrepository/DeploymentImpl.java
+++ b/core/src/main/java/org/ironjacamar/core/deploymentrepository/DeploymentImpl.java
@@ -37,6 +37,9 @@ import java.util.Collection;
  */
 public class DeploymentImpl implements Deployment
 {
+   /** Activated */
+   private boolean activated;
+
    /** The identifier */
    private String identifier;
    
@@ -86,6 +89,7 @@ public class DeploymentImpl implements Deployment
                          Collection<ConnectionFactory> connectionFactories,
                          Collection<AdminObject> adminObjects)
    {
+      this.activated = false;
       this.identifier = identifier;
       this.name = name;
       this.archive = archive;
@@ -172,55 +176,79 @@ public class DeploymentImpl implements Deployment
    /**
     * {@inheritDoc}
     */
-   public void activate() throws Exception
+   public boolean isActivated()
    {
-      if (connectionFactories != null)
-      {
-         for (ConnectionFactory cf : connectionFactories)
-         {
-            cf.activate();
-         }
-      }
-
-      if (adminObjects != null)
-      {
-         for (AdminObject ao : adminObjects)
-         {
-            ao.activate();
-         }
-      }
-
-      if (resourceAdapter != null)
-      {
-         resourceAdapter.activate();
-      }
+      return activated;
    }
 
    /**
     * {@inheritDoc}
     */
-   public void deactivate() throws Exception
+   public boolean activate() throws Exception
    {
-      if (connectionFactories != null)
+      if (!activated)
       {
-         for (ConnectionFactory cf : connectionFactories)
+         if (connectionFactories != null)
          {
-            cf.deactivate();
+            for (ConnectionFactory cf : connectionFactories)
+            {
+               cf.activate();
+            }
          }
+
+         if (adminObjects != null)
+         {
+            for (AdminObject ao : adminObjects)
+            {
+               ao.activate();
+            }
+         }
+
+         if (resourceAdapter != null)
+         {
+            resourceAdapter.activate();
+         }
+
+         activated = true;
+         return true;
       }
 
-      if (adminObjects != null)
-      {
-         for (AdminObject ao : adminObjects)
-         {
-            ao.deactivate();
-         }
-      }
+      return false;
+   }
 
-      if (resourceAdapter != null)
+   /**
+    * {@inheritDoc}
+    */
+   public boolean deactivate() throws Exception
+   {
+      if (activated)
       {
-         resourceAdapter.deactivate();
+         if (connectionFactories != null)
+         {
+            for (ConnectionFactory cf : connectionFactories)
+            {
+               cf.deactivate();
+            }
+         }
+
+         if (adminObjects != null)
+         {
+            for (AdminObject ao : adminObjects)
+            {
+               ao.deactivate();
+            }
+         }
+
+         if (resourceAdapter != null)
+         {
+            resourceAdapter.deactivate();
+         }
+
+         activated = false;
+         return true;
       }
+      
+      return false;
    }
 
    /**

--- a/core/src/main/java/org/ironjacamar/core/deploymentrepository/ResourceAdapterImpl.java
+++ b/core/src/main/java/org/ironjacamar/core/deploymentrepository/ResourceAdapterImpl.java
@@ -36,6 +36,9 @@ import javax.resource.spi.BootstrapContext;
  */
 public class ResourceAdapterImpl implements ResourceAdapter
 {
+   /** Activated */
+   private boolean activated;
+
    /** The resource adapter */
    private javax.resource.spi.ResourceAdapter resourceAdapter;
 
@@ -65,6 +68,7 @@ public class ResourceAdapterImpl implements ResourceAdapter
                               StatisticsPlugin statistics,
                               Recovery recovery)
    {
+      this.activated = false;
       this.resourceAdapter = resourceAdapter;
       this.bc = bc;
       this.configProperties = configProperties;
@@ -72,6 +76,14 @@ public class ResourceAdapterImpl implements ResourceAdapter
       this.recovery = recovery;
    }
    
+   /**
+    * {@inheritDoc}
+    */
+   public boolean isActivated()
+   {
+      return activated;
+   }
+
    /**
     * {@inheritDoc}
     */
@@ -115,16 +127,32 @@ public class ResourceAdapterImpl implements ResourceAdapter
    /**
     * {@inheritDoc}
     */
-   public void activate() throws Exception
+   public boolean activate() throws Exception
    {
-      resourceAdapter.start(bc);
+      if (!activated)
+      {
+         resourceAdapter.start(bc);
+
+         activated = true;
+         return true;
+      }
+
+      return false;
    }
 
    /**
     * {@inheritDoc}
     */
-   public void deactivate() throws Exception
+   public boolean deactivate() throws Exception
    {
-      resourceAdapter.stop();
+      if (activated)
+      {
+         resourceAdapter.stop();
+
+         activated = false;
+         return true;
+      }
+
+      return false;
    }
 }

--- a/core/src/main/java/org/ironjacamar/core/spi/transaction/TransactionIntegration.java
+++ b/core/src/main/java/org/ironjacamar/core/spi/transaction/TransactionIntegration.java
@@ -106,8 +106,6 @@ public interface TransactionIntegration
     * @param pad Should the branch qualifier for Xid's be padded
     * @param override Should the isSameRM value be overriden; <code>null</code> for instance equally check
     * @param wrapXAResource Should the XAResource be wrapped
-    * @param recoverUserName The user name for recovery
-    * @param recoverPassword The password for recovery
     * @param recoverSecurityDomain The security domain for recovery
     * @param subjectFactory The subject factory
     * @param plugin The recovery plugin
@@ -117,7 +115,6 @@ public interface TransactionIntegration
    public XAResourceRecovery createXAResourceRecovery(ManagedConnectionFactory mcf,
                                                       Boolean pad, Boolean override, 
                                                       Boolean wrapXAResource,
-                                                      String recoverUserName, String recoverPassword, 
                                                       String recoverSecurityDomain,
                                                       SubjectFactory subjectFactory,
                                                       RecoveryPlugin plugin,

--- a/core/src/main/java/org/ironjacamar/core/tx/narayana/TransactionIntegrationImpl.java
+++ b/core/src/main/java/org/ironjacamar/core/tx/narayana/TransactionIntegrationImpl.java
@@ -158,14 +158,13 @@ public class TransactionIntegrationImpl implements TransactionIntegration
    public XAResourceRecovery createXAResourceRecovery(ManagedConnectionFactory mcf,
                                                       Boolean pad, Boolean override, 
                                                       Boolean wrapXAResource,
-                                                      String recoverUserName, String recoverPassword, 
                                                       String recoverSecurityDomain,
                                                       SubjectFactory subjectFactory,
                                                       RecoveryPlugin plugin,
                                                       XAResourceStatistics xastat)
    {
       return new XAResourceRecoveryImpl(this, mcf, pad, override, wrapXAResource,
-                                        recoverUserName, recoverPassword, recoverSecurityDomain,
+                                        recoverSecurityDomain,
                                         subjectFactory, plugin, xastat);
    }
 

--- a/core/src/main/java/org/ironjacamar/core/tx/noopts/TransactionIntegrationImpl.java
+++ b/core/src/main/java/org/ironjacamar/core/tx/noopts/TransactionIntegrationImpl.java
@@ -133,7 +133,7 @@ public class TransactionIntegrationImpl implements TransactionIntegration
    public XAResourceRecovery createXAResourceRecovery(ResourceAdapter rar, ActivationSpec as,
                                                       String productName, String productVersion)
    {
-      return new XAResourceRecoveryImpl();
+      return new XAResourceRecoveryImpl(rar, as);
    }
 
    /**
@@ -142,13 +142,12 @@ public class TransactionIntegrationImpl implements TransactionIntegration
    public XAResourceRecovery createXAResourceRecovery(ManagedConnectionFactory mcf,
                                                       Boolean pad, Boolean override, 
                                                       Boolean wrapXAResource,
-                                                      String recoverUserName, String recoverPassword, 
                                                       String recoverSecurityDomain,
                                                       SubjectFactory subjectFactory,
                                                       RecoveryPlugin plugin,
                                                       XAResourceStatistics xastat)
    {
-      return new XAResourceRecoveryImpl();
+      return new XAResourceRecoveryImpl(mcf, recoverSecurityDomain, subjectFactory);
    }
 
    /**

--- a/core/src/main/java/org/ironjacamar/core/tx/noopts/XAResourceRecoveryRegistryImpl.java
+++ b/core/src/main/java/org/ironjacamar/core/tx/noopts/XAResourceRecoveryRegistryImpl.java
@@ -1,0 +1,62 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.ironjacamar.core.tx.noopts;
+
+import org.ironjacamar.core.spi.transaction.recovery.XAResourceRecovery;
+import org.ironjacamar.core.spi.transaction.recovery.XAResourceRecoveryRegistry;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * A XAResourceRecoveryRegistry implementation
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ */
+public class XAResourceRecoveryRegistryImpl implements XAResourceRecoveryRegistry
+{
+   /** Instances */
+   private Collection<XAResourceRecovery> instances;
+   
+   /**
+    * Constructor
+    */
+   public XAResourceRecoveryRegistryImpl()
+   {
+      this.instances = new ArrayList<>();
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   public void addXAResourceRecovery(XAResourceRecovery recovery)
+   {
+      instances.add(recovery);
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   public void removeXAResourceRecovery(XAResourceRecovery recovery)
+   {
+      instances.remove(recovery);
+   }
+}

--- a/embedded/src/main/resources/noop-transaction.xml
+++ b/embedded/src/main/resources/noop-transaction.xml
@@ -48,6 +48,12 @@
     <uncallback method="removeListener"/>
   </bean>
 
+  <!-- XAResourceRecoveryRegistry -->
+  <bean name="XAResourceRecoveryRegistry"
+        interface="org.ironjacamar.core.spi.transaction.recovery.XAResourceRecoveryRegistry" 
+        class="org.ironjacamar.core.tx.noopts.XAResourceRecoveryRegistryImpl">
+  </bean>
+
   <!-- Transaction integration -->
   <bean name="TransactionIntegration"
         interface="org.ironjacamar.core.spi.transaction.TransactionIntegration"
@@ -57,7 +63,7 @@
       <parameter><inject bean="TransactionSynchronizationRegistry"/></parameter>
       <parameter><inject bean="UserTransactionRegistry"/></parameter>
       <parameter><inject bean="XATerminator"/></parameter>
-      <parameter><null/></parameter>
+      <parameter><inject bean="XAResourceRecoveryRegistry"/></parameter>
     </constructor>
   </bean>
 

--- a/testsuite/src/test/java/org/ironjacamar/core/connectionmanager/pool/dflt/RecoveryTestCase.java
+++ b/testsuite/src/test/java/org/ironjacamar/core/connectionmanager/pool/dflt/RecoveryTestCase.java
@@ -1,0 +1,133 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.ironjacamar.core.connectionmanager.pool.dflt;
+
+import org.ironjacamar.embedded.Configuration;
+import org.ironjacamar.embedded.Deployment;
+import org.ironjacamar.embedded.dsl.resourceadapters20.api.ResourceAdaptersDescriptor;
+import org.ironjacamar.embedded.junit4.IronJacamar;
+import org.ironjacamar.rars.ResourceAdapterFactory;
+import org.ironjacamar.rars.txlog.TxLogConnection;
+import org.ironjacamar.rars.txlog.TxLogConnectionFactory;
+
+import java.net.URL;
+
+import javax.annotation.Resource;
+import javax.resource.spi.TransactionSupport.TransactionSupportLevel;
+
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Recovery test case
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ */
+@RunWith(IronJacamar.class)
+@Configuration(full = false)
+public class RecoveryTestCase
+{
+   /** The txlog connection factory */
+   @Resource(mappedName = "java:/eis/TxLogConnectionFactory")
+   private static TxLogConnectionFactory cf;
+
+   /**
+    * Naming
+    * @throws Throwable In case of an error
+    */
+   @Deployment(order = 1)
+   private static URL createNaming() throws Throwable
+   {
+      return Configuration.class.getClassLoader().getResource("naming.xml");
+   }
+   
+   /**
+    * Stdio
+    * @throws Throwable In case of an error
+    */
+   @Deployment(order = 2)
+   private static URL createStdIO() throws Throwable
+   {
+      return Configuration.class.getClassLoader().getResource("stdio.xml");
+   }
+   
+   /**
+    * NoopTS
+    * @throws Throwable In case of an error
+    */
+   @Deployment(order = 3)
+   private static URL createNoopTS() throws Throwable
+   {
+      return Configuration.class.getClassLoader().getResource("noop-transaction.xml");
+   }
+   
+   /**
+    * JCA
+    * @throws Throwable In case of an error
+    */
+   @Deployment(order = 4)
+   private static URL createJCA() throws Throwable
+   {
+      return Configuration.class.getClassLoader().getResource("jca.xml");
+   }
+   
+   /**
+    * The resource adapter
+    * @throws Throwable In case of an error
+    */
+   @Deployment(order = 5)
+   private static ResourceAdapterArchive createResourceAdapter() throws Throwable
+   {
+      return ResourceAdapterFactory.createTxLogRar();
+   }
+   
+   /**
+    * The activation
+    * @throws Throwable In case of an error
+    */
+   @Deployment(order = 6)
+   private static ResourceAdaptersDescriptor createActivation() throws Throwable
+   {
+      return ResourceAdapterFactory.createTxLogDeployment(TransactionSupportLevel.XATransaction);
+   }
+   
+   /**
+    * Recovery
+    * @throws Throwable In case of an error
+    */
+   @Test
+   @SuppressWarnings("unchecked")
+   public void testRecovery() throws Throwable
+   {
+      assertNotNull(cf);
+      
+      TxLogConnection c = cf.getConnection();
+      assertNotNull(c);
+
+      assertTrue(c.isRecovery());
+      
+      c.close();
+   }
+}

--- a/testsuite/src/test/java/org/ironjacamar/rars/ResourceAdapterFactory.java
+++ b/testsuite/src/test/java/org/ironjacamar/rars/ResourceAdapterFactory.java
@@ -256,8 +256,7 @@ public class ResourceAdapterFactory
          org.ironjacamar.embedded.dsl.resourceadapters20.api.XaPoolType dashRaXmlPt = dashRaXmlCdt.getOrCreateXaPool()
             .minPoolSize(0).initialPoolSize(0).maxPoolSize(10);
 
-         org.ironjacamar.embedded.dsl.resourceadapters20.api.RecoverType dashRaXmlRyt = dashRaXmlCdt
-               .getOrCreateRecovery().noRecovery(Boolean.TRUE);
+         dashRaXmlCdt.getOrCreateRecovery().getOrCreateRecoveryCredential().securityDomain("DefaultSecurityDomain");
       }
 
       return dashRaXml;

--- a/testsuite/src/test/java/org/ironjacamar/rars/txlog/TxLogConnection.java
+++ b/testsuite/src/test/java/org/ironjacamar/rars/txlog/TxLogConnection.java
@@ -63,6 +63,12 @@ public interface TxLogConnection
    public boolean isInPool();
 
    /**
+    * Is recovery
+    * @return The value
+    */
+   public boolean isRecovery();
+
+   /**
     * Get the transaction timeout
     * @return The value
     */

--- a/testsuite/src/test/java/org/ironjacamar/rars/txlog/TxLogConnectionImpl.java
+++ b/testsuite/src/test/java/org/ironjacamar/rars/txlog/TxLogConnectionImpl.java
@@ -99,6 +99,14 @@ public class TxLogConnectionImpl implements TxLogConnection
    /**
     * {@inheritDoc}
     */
+   public boolean isRecovery()
+   {
+      return mc.isRecovery();
+   }
+
+   /**
+    * {@inheritDoc}
+    */
    public int getTransactionTimeout()
    {
       try

--- a/testsuite/src/test/java/org/ironjacamar/rars/txlog/TxLogManagedConnection.java
+++ b/testsuite/src/test/java/org/ironjacamar/rars/txlog/TxLogManagedConnection.java
@@ -382,6 +382,15 @@ public class TxLogManagedConnection implements ManagedConnection, LocalTransacti
       return inPool;
    }
 
+   /**
+    * Is recovery
+    * @return The value
+    */
+   boolean isRecovery()
+   {
+      return mcf.didRecoveryTrigger();
+   }
+
    // LocalTransaction
 
    /**
@@ -547,6 +556,7 @@ public class TxLogManagedConnection implements ManagedConnection, LocalTransacti
     */
    public Xid[] recover(int flag) throws XAException
    {
+      mcf.recoveryTriggered();
       return new Xid[] {};
    }
  

--- a/testsuite/src/test/java/org/ironjacamar/rars/txlog/TxLogManagedConnectionFactory.java
+++ b/testsuite/src/test/java/org/ironjacamar/rars/txlog/TxLogManagedConnectionFactory.java
@@ -49,12 +49,15 @@ public class TxLogManagedConnectionFactory implements ManagedConnectionFactory
    /** The logwriter */
    private PrintWriter logwriter;
 
+   /** Recovery triggered */
+   private boolean recovery;
+   
    /**
     * Default constructor
     */
    public TxLogManagedConnectionFactory()
    {
-
+      this.recovery = false;
    }
 
    /**
@@ -145,6 +148,23 @@ public class TxLogManagedConnectionFactory implements ManagedConnectionFactory
       logwriter = out;
    }
 
+   /**
+    * Recovery triggered
+    */
+   void recoveryTriggered()
+   {
+      recovery = true;
+   }
+   
+   /**
+    * Recovery triggered
+    * @return The value
+    */
+   boolean didRecoveryTrigger()
+   {
+      return recovery;
+   }
+   
    /** 
     * Returns a hash code value for the object.
     * @return A hash code value for this object.


### PR DESCRIPTION
This pull requests adds support for outbound recovery.

NoopTS has been changed to trigger a single recovery pass of the associated XAResource instances during startup.

Furthermore the signature of the deployment repository components has been changed for activate and deactivate in order to provide feedback to the caller on the result of the operation. This will help in making lifecycle changes easier. F.ex. recovery can be activated and deactivated in a cycle now at run-time.