### PR TITLE
[JBEAP-2995] Log datasource name in warn message when Network Adapter fails to establish connection with database.

### DIFF
--- a/core/src/main/java/org/jboss/jca/core/CoreLogger.java
+++ b/core/src/main/java/org/jboss/jca/core/CoreLogger.java
@@ -412,10 +412,11 @@ public interface CoreLogger extends BasicLogger
    /**
     * Unable to fill pool
     * @param t The exception
+    * @param jndiName the jndi-name
     */
    @LogMessage(level = WARN)
-   @Message(id = 610, value = "Unable to fill pool")
-   public void unableFillPool(@Cause Throwable t);
+   @Message(id = 610, value = "Unable to fill pool: %s")
+   public void unableFillPool(@Cause Throwable t, String jndiName);
    
    /**
     * Background validation was specified with a non compliant ManagedConnectionFactory interface

--- a/core/src/main/java/org/jboss/jca/core/connectionmanager/pool/mcp/SemaphoreArrayListManagedConnectionPool.java
+++ b/core/src/main/java/org/jboss/jca/core/connectionmanager/pool/mcp/SemaphoreArrayListManagedConnectionPool.java
@@ -802,7 +802,7 @@ public class SemaphoreArrayListManagedConnectionPool implements ManagedConnectio
          }
          else if (FlushMode.GRACEFULLY == mode)
          {
-            log.tracef("Gracefully flushing pool checkedOut=%s inPool=%s",checkedOut , cls);
+            log.tracef("Gracefully flushing pool checkedOut=%s inPool=%s", checkedOut , cls);
 
             // Mark checked out connections as requiring destruction upon return
             for (ConnectionListener cl : checkedOut)
@@ -1146,7 +1146,7 @@ public class SemaphoreArrayListManagedConnectionPool implements ManagedConnectio
                   }
                   catch (ResourceException re)
                   {
-                     log.unableFillPool(re);
+                     log.unableFillPool(re, cm.getJndiName());
                      return;
                   }
                }
@@ -1238,7 +1238,7 @@ public class SemaphoreArrayListManagedConnectionPool implements ManagedConnectio
                      }
                      catch (ResourceException re)
                      {
-                        log.unableFillPool(re);
+                        log.unableFillPool(re, cm.getJndiName());
                         return;
                      }
                   }

--- a/core/src/main/java/org/jboss/jca/core/connectionmanager/pool/mcp/SemaphoreConcurrentLinkedDequeManagedConnectionPool.java
+++ b/core/src/main/java/org/jboss/jca/core/connectionmanager/pool/mcp/SemaphoreConcurrentLinkedDequeManagedConnectionPool.java
@@ -554,7 +554,8 @@ public class SemaphoreConcurrentLinkedDequeManagedConnectionPool implements Mana
                else
                {
                   throw new ResourceException(
-                     bundle.unexpectedThrowableWhileTryingCreateConnection(clw != null ? clw.getConnectionListener() : null), t);
+                     bundle.unexpectedThrowableWhileTryingCreateConnection(
+                             clw != null ? clw.getConnectionListener() : null), t);
                }
             }
          } 
@@ -757,7 +758,7 @@ public class SemaphoreConcurrentLinkedDequeManagedConnectionPool implements Mana
                   if (entry.getValue().isCheckedOut())
                      checkedOut.add(entry.getKey());
                }
-               log.tracef("Flushing pool checkedOut=%s inPool=%s",checkedOut , cls);
+               log.tracef("Flushing pool checkedOut=%s inPool=%s", checkedOut , cls);
             }
 
             // Mark checked out connections as requiring destruction
@@ -802,7 +803,7 @@ public class SemaphoreConcurrentLinkedDequeManagedConnectionPool implements Mana
                   if (entry.getValue().isCheckedOut())
                      checkedOut.add(entry.getKey());
                }
-               log.tracef("Gracefully flushing pool checkedOut=%s inPool=%s",checkedOut , cls);
+               log.tracef("Gracefully flushing pool checkedOut=%s inPool=%s", checkedOut , cls);
             }
 
             for (Entry<ConnectionListener, ConnectionListenerWrapper> entry : cls.entrySet()) 
@@ -1165,7 +1166,7 @@ public class SemaphoreConcurrentLinkedDequeManagedConnectionPool implements Mana
                   }
                   catch (ResourceException re) 
                   {
-                     log.unableFillPool(re);
+                     log.unableFillPool(re, cm.getJndiName());
                      return;
                   }
                } 
@@ -1249,7 +1250,7 @@ public class SemaphoreConcurrentLinkedDequeManagedConnectionPool implements Mana
                      } 
                      catch (ResourceException re) 
                      {
-                        log.unableFillPool(re);
+                        log.unableFillPool(re, cm.getJndiName());
                         return;
                      }
                   }


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/JBEAP-2995

Changing the `public void unableFillPool(Throwable t)` in `CoreLogger.java` to `public void unableFillPool(Throwable t, String jndiName)` to include the jndi-name in the log.