### PR TITLE
[BZ:1315439] [GSS] (6.4.z) Difficult to identify datasource with wrong credentials if security-domain is used.

### DIFF
--- a/core/src/main/java/org/jboss/jca/core/CoreLogger.java
+++ b/core/src/main/java/org/jboss/jca/core/CoreLogger.java
@@ -445,12 +445,13 @@ public interface CoreLogger extends BasicLogger
 
    /**
     * Exception during createSubject()
+    * @param jndiName The jndi-name
     * @param description throwable description
     * @param t The exception
     */
    @LogMessage(level = ERROR)
-   @Message(id = 614, value = "Exception during createSubject() %s")
-   public void exceptionDuringCreateSubject(String description, @Cause Throwable t);   
+   @Message(id = 614, value = "Exception during createSubject() for %s: %s")
+   public void exceptionDuringCreateSubject(String jndiName, String description, @Cause Throwable t);
 
    /**
     * Going to destroy connection listener during shutdown

--- a/core/src/main/java/org/jboss/jca/core/connectionmanager/pool/strategy/PoolBySubject.java
+++ b/core/src/main/java/org/jboss/jca/core/connectionmanager/pool/strategy/PoolBySubject.java
@@ -85,7 +85,7 @@ public class PoolBySubject extends AbstractPrefillPool
          ConnectionManager cm = getConnectionManager();
          ManagedConnectionFactory mcf = getManagedConnectionFactory();
        
-         Subject subject = createSubject(cm.getSubjectFactory(), cm.getSecurityDomain(), mcf);
+         Subject subject = createSubject(cm.getSubjectFactory(), cm.getSecurityDomain(), mcf, cm.getJndiName());
   
          if (subject != null)
             return internalTestConnection(null, subject);
@@ -111,11 +111,13 @@ public class PoolBySubject extends AbstractPrefillPool
     * @param subjectFactory The subject factory
     * @param securityDomain The security domain
     * @param mcf The managed connection factory
+    * @param jndiName The jndi-name
     * @return The subject; <code>null</code> in case of an error
     */
    protected Subject createSubject(final SubjectFactory subjectFactory,
                                    final String securityDomain,
-                                   final ManagedConnectionFactory mcf)
+                                   final ManagedConnectionFactory mcf,
+                                   final String jndiName)
    {
       if (subjectFactory == null)
          throw new IllegalArgumentException("SubjectFactory is null");
@@ -144,7 +146,7 @@ public class PoolBySubject extends AbstractPrefillPool
             }
             catch (Throwable t)
             {
-               log.exceptionDuringCreateSubject(t.getMessage(), t);
+               log.exceptionDuringCreateSubject(jndiName, t.getMessage(), t);
             }
 
             return null;

--- a/deployers/src/main/java/org/jboss/jca/deployers/common/AbstractDsDeployer.java
+++ b/deployers/src/main/java/org/jboss/jca/deployers/common/AbstractDsDeployer.java
@@ -763,7 +763,7 @@ public abstract class AbstractDsDeployer
          Subject subject = null;
 
          if (subjectFactory != null)
-            subject = createSubject(subjectFactory, securityDomain, mcf);
+            subject = createSubject(subjectFactory, securityDomain, mcf, jndiName);
 
          pp.prefill(subject, null, false);
       }
@@ -1145,7 +1145,7 @@ public abstract class AbstractDsDeployer
          Subject subject = null;
 
          if (subjectFactory != null)
-            subject = createSubject(subjectFactory, securityDomain, mcf);
+            subject = createSubject(subjectFactory, securityDomain, mcf, jndiName);
 
          pp.prefill(subject, null, noTxSeparatePool.booleanValue());
       }
@@ -1430,11 +1430,13 @@ public abstract class AbstractDsDeployer
     * @param subjectFactory The subject factory
     * @param securityDomain The security domain
     * @param mcf The managed connection factory
+    * @param jndiName The jndi-name of the data-source
     * @return The subject; <code>null</code> in case of an error
     */
    protected Subject createSubject(final SubjectFactory subjectFactory,
                                    final String securityDomain,
-                                   final ManagedConnectionFactory mcf)
+                                   final ManagedConnectionFactory mcf,
+                                   final String jndiName)
    {
       if (subjectFactory == null)
          throw new IllegalArgumentException("SubjectFactory is null");
@@ -1466,7 +1468,7 @@ public abstract class AbstractDsDeployer
             }
             catch (Throwable t)
             {
-               log.error("Exception during createSubject()" + t.getMessage(), t);
+               log.error("Exception during createSubject() for " + jndiName + ": " + t.getMessage(), t);
             }
 
             return null;


### PR DESCRIPTION
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1315439

Added jndi-name in the console log