### PR TITLE
[BZ:1315439] [GSS] (6.4.z) Difficult to identify datasource with wrong credentials if security-domain is used.

### DIFF
--- a/core/src/main/java/org/jboss/jca/core/CoreLogger.java
+++ b/core/src/main/java/org/jboss/jca/core/CoreLogger.java
@@ -383,12 +383,13 @@ public interface CoreLogger extends BasicLogger
 
    /**
     * Exception during createSubject()
+    * @param jndiName The jndi-name
     * @param description throwable description
     * @param t The exception
     */
    @LogMessage(level = ERROR)
-   @Message(id = 614, value = "Exception during createSubject() %s")
-   public void exceptionDuringCreateSubject(String description, @Cause Throwable t);   
+   @Message(id = 614, value = "Exception during createSubject() for %s: %s")
+   public void exceptionDuringCreateSubject(String jndiName, String description, @Cause Throwable t);
 
    /**
     * Going to destroy connection listener during shutdown

--- a/core/src/main/java/org/jboss/jca/core/connectionmanager/pool/strategy/PoolBySubject.java
+++ b/core/src/main/java/org/jboss/jca/core/connectionmanager/pool/strategy/PoolBySubject.java
@@ -82,7 +82,7 @@ public class PoolBySubject extends AbstractPrefillPool
          ConnectionManager cm = (ConnectionManager)getConnectionListenerFactory();
          ManagedConnectionFactory mcf = getManagedConnectionFactory();
        
-         Subject subject = createSubject(cm.getSubjectFactory(), cm.getSecurityDomain(), mcf);
+         Subject subject = createSubject(cm.getSubjectFactory(), cm.getSecurityDomain(), mcf, cm.getJndiName());
   
          if (subject != null)
             return internalTestConnection(null, subject);
@@ -100,11 +100,13 @@ public class PoolBySubject extends AbstractPrefillPool
     * @param subjectFactory The subject factory
     * @param securityDomain The security domain
     * @param mcf The managed connection factory
+    * @param jndiName The jndi-name
     * @return The subject; <code>null</code> in case of an error
     */
    protected Subject createSubject(final SubjectFactory subjectFactory,
                                    final String securityDomain,
-                                   final ManagedConnectionFactory mcf)
+                                   final ManagedConnectionFactory mcf,
+                                   final String jndiName)
    {
       if (subjectFactory == null)
          throw new IllegalArgumentException("SubjectFactory is null");
@@ -136,7 +138,7 @@ public class PoolBySubject extends AbstractPrefillPool
             }
             catch (Throwable t)
             {
-               log.exceptionDuringCreateSubject(t.getMessage(), t);
+               log.exceptionDuringCreateSubject(jndiName, t.getMessage(), t);
             }
 
             return null;

--- a/deployers/src/main/java/org/jboss/jca/deployers/common/AbstractDsDeployer.java
+++ b/deployers/src/main/java/org/jboss/jca/deployers/common/AbstractDsDeployer.java
@@ -597,7 +597,7 @@ public abstract class AbstractDsDeployer
          Subject subject = null;
 
          if (subjectFactory != null)
-            subject = createSubject(subjectFactory, securityDomain, mcf);
+            subject = createSubject(subjectFactory, securityDomain, mcf, jndiName);
 
          pp.prefill(subject, null, false);
       }
@@ -888,7 +888,7 @@ public abstract class AbstractDsDeployer
          Subject subject = null;
 
          if (subjectFactory != null)
-            subject = createSubject(subjectFactory, securityDomain, mcf);
+            subject = createSubject(subjectFactory, securityDomain, mcf, jndiName);
 
          pp.prefill(subject, null, noTxSeparatePool.booleanValue());
       }
@@ -1063,11 +1063,13 @@ public abstract class AbstractDsDeployer
     * @param subjectFactory The subject factory
     * @param securityDomain The security domain
     * @param mcf The managed connection factory
+    * @param jndiName The jndi-name of the data-source
     * @return The subject; <code>null</code> in case of an error
     */
    protected Subject createSubject(final SubjectFactory subjectFactory,
                                    final String securityDomain,
-                                   final ManagedConnectionFactory mcf)
+                                   final ManagedConnectionFactory mcf,
+                                   final String jndiName)
    {
       if (subjectFactory == null)
          throw new IllegalArgumentException("SubjectFactory is null");
@@ -1099,7 +1101,7 @@ public abstract class AbstractDsDeployer
             }
             catch (Throwable t)
             {
-               log.error("Exception during createSubject()" + t.getMessage(), t);
+               log.error("Exception during createSubject() for " + jndiName + ": " + t.getMessage(), t);
             }
 
             return null;


### PR DESCRIPTION
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1315439

PR for 1.3 branch: https://github.com/ironjacamar/ironjacamar/pull/479