### PR TITLE
[JBJCA-1317] Log jndi-name in console log to identify datasource with wrong credentials if security-domain is used

### DIFF
--- a/core/src/main/java/org/jboss/jca/core/CoreLogger.java
+++ b/core/src/main/java/org/jboss/jca/core/CoreLogger.java
@@ -445,12 +445,13 @@ public interface CoreLogger extends BasicLogger
 
    /**
     * Exception during createSubject()
+    * @param jndiName The jndi-name
     * @param description throwable description
     * @param t The exception
     */
    @LogMessage(level = ERROR)
-   @Message(id = 614, value = "Exception during createSubject() %s")
-   public void exceptionDuringCreateSubject(String description, @Cause Throwable t);   
+   @Message(id = 614, value = "Exception during createSubject() for %s: %s")
+   public void exceptionDuringCreateSubject(String jndiName, String description, @Cause Throwable t);
 
    /**
     * Going to destroy connection listener during shutdown

--- a/core/src/main/java/org/jboss/jca/core/connectionmanager/pool/strategy/PoolBySubject.java
+++ b/core/src/main/java/org/jboss/jca/core/connectionmanager/pool/strategy/PoolBySubject.java
@@ -83,7 +83,7 @@ public class PoolBySubject extends AbstractPrefillPool
          ConnectionManager cm = getConnectionManager();
          ManagedConnectionFactory mcf = getManagedConnectionFactory();
        
-         Subject subject = createSubject(cm.getSubjectFactory(), cm.getSecurityDomain(), mcf);
+         Subject subject = createSubject(cm.getSubjectFactory(), cm.getSecurityDomain(), mcf, cm.getJndiName());
   
          if (subject != null)
             return internalTestConnection(null, subject);
@@ -109,11 +109,13 @@ public class PoolBySubject extends AbstractPrefillPool
     * @param subjectFactory The subject factory
     * @param securityDomain The security domain
     * @param mcf The managed connection factory
+    * @param jndiName The jndi-name
     * @return The subject; <code>null</code> in case of an error
     */
    protected Subject createSubject(final SubjectFactory subjectFactory,
                                    final String securityDomain,
-                                   final ManagedConnectionFactory mcf)
+                                   final ManagedConnectionFactory mcf,
+                                   final String jndiName)
    {
       if (subjectFactory == null)
          throw new IllegalArgumentException("SubjectFactory is null");
@@ -142,7 +144,7 @@ public class PoolBySubject extends AbstractPrefillPool
             }
             catch (Throwable t)
             {
-               log.exceptionDuringCreateSubject(t.getMessage(), t);
+               log.exceptionDuringCreateSubject(jndiName, t.getMessage(), t);
             }
 
             return null;

--- a/deployers/src/main/java/org/jboss/jca/deployers/common/AbstractDsDeployer.java
+++ b/deployers/src/main/java/org/jboss/jca/deployers/common/AbstractDsDeployer.java
@@ -751,7 +751,7 @@ public abstract class AbstractDsDeployer
          Subject subject = null;
 
          if (subjectFactory != null)
-            subject = createSubject(subjectFactory, securityDomain, mcf);
+            subject = createSubject(subjectFactory, securityDomain, mcf, jndiName);
 
          pp.prefill(subject, null, false);
       }
@@ -1122,7 +1122,7 @@ public abstract class AbstractDsDeployer
          Subject subject = null;
 
          if (subjectFactory != null)
-            subject = createSubject(subjectFactory, securityDomain, mcf);
+            subject = createSubject(subjectFactory, securityDomain, mcf, jndiName);
 
          pp.prefill(subject, null, noTxSeparatePool.booleanValue());
       }
@@ -1404,11 +1404,13 @@ public abstract class AbstractDsDeployer
     * @param subjectFactory The subject factory
     * @param securityDomain The security domain
     * @param mcf The managed connection factory
+    * @param jndiName The jndi-name of the data-source
     * @return The subject; <code>null</code> in case of an error
     */
    protected Subject createSubject(final SubjectFactory subjectFactory,
                                    final String securityDomain,
-                                   final ManagedConnectionFactory mcf)
+                                   final ManagedConnectionFactory mcf,
+                                   final String jndiName)
    {
       if (subjectFactory == null)
          throw new IllegalArgumentException("SubjectFactory is null");
@@ -1440,7 +1442,7 @@ public abstract class AbstractDsDeployer
             }
             catch (Throwable t)
             {
-               log.error("Exception during createSubject()" + t.getMessage(), t);
+               log.error("Exception during createSubject() for " + jndiName + ": " + t.getMessage(), t);
             }
 
             return null;


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/JBJCA-1317