### PR TITLE
[#437] Lazy connection manager

### DIFF
--- a/core/src/main/java/org/ironjacamar/core/api/connectionmanager/ConnectionManager.java
+++ b/core/src/main/java/org/ironjacamar/core/api/connectionmanager/ConnectionManager.java
@@ -23,12 +23,51 @@ package org.ironjacamar.core.api.connectionmanager;
 
 import org.ironjacamar.core.api.connectionmanager.listener.ConnectionListener;
 
+import javax.resource.ResourceException;
+import javax.resource.spi.ConnectionRequestInfo;
+import javax.resource.spi.LazyAssociatableConnectionManager;
+import javax.resource.spi.LazyEnlistableConnectionManager;
+import javax.resource.spi.ManagedConnection;
+import javax.resource.spi.ManagedConnectionFactory;
+
 /**
  * A connection manager
  * @author <a href="jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
  */
-public interface ConnectionManager extends javax.resource.spi.ConnectionManager
+public interface ConnectionManager extends javax.resource.spi.ConnectionManager,
+                                           LazyAssociatableConnectionManager,
+                                           LazyEnlistableConnectionManager
 {
+   /**
+    * Associate a managed connection to a logical connection
+    *
+    * @param connection The connection
+    * @param mcf The managed connection factory
+    * @param cri The connection request information
+    * @return The managed connection
+    * @exception ResourceException Thrown if an error occurs
+    */
+   public ManagedConnection associateManagedConnection(Object connection, ManagedConnectionFactory mcf,
+                                                       ConnectionRequestInfo cri)
+      throws ResourceException;
+
+   /**
+    * Dissociate a managed connection from a logical connection. The return value
+    * of this method will indicate if the managed connection has more connections
+    * attached (false), or if it was return to the pool (true).
+    *
+    * If the managed connection is return to the pool its <code>cleanup</code> method
+    * will be called
+    *
+    * @param connection The connection
+    * @param mc The managed connection
+    * @param mcf The managed connection factory
+    * @return True if the managed connection was freed; otherwise false
+    * @exception ResourceException Thrown if an error occurs
+    */
+   public boolean dissociateManagedConnection(Object connection, ManagedConnection mc, ManagedConnectionFactory mcf)
+      throws ResourceException;
+
    /**
     * Return the connection listener
     * @param cl The connection listener

--- a/core/src/main/java/org/ironjacamar/core/connectionmanager/listener/AbstractConnectionListener.java
+++ b/core/src/main/java/org/ironjacamar/core/connectionmanager/listener/AbstractConnectionListener.java
@@ -237,6 +237,14 @@ public abstract class AbstractConnectionListener implements ConnectionListener
    /**
     * {@inheritDoc}
     */
+   public ManagedConnectionPool getManagedConnectionPool()
+   {
+      return mcp;
+   }
+
+   /**
+    * {@inheritDoc}
+    */
    public Object getConnection() throws ResourceException
    {
       Object result = mc.getConnection(credential.getSubject(), credential.getConnectionRequestInfo());
@@ -260,6 +268,14 @@ public abstract class AbstractConnectionListener implements ConnectionListener
    public void addConnection(Object c)
    {
       connectionHandles.add(c);
+   }
+   
+   /**
+    * {@inheritDoc}
+    */
+   public void removeConnection(Object c)
+   {
+      connectionHandles.remove(c);
    }
    
    /**

--- a/core/src/main/java/org/ironjacamar/core/connectionmanager/listener/ConnectionListener.java
+++ b/core/src/main/java/org/ironjacamar/core/connectionmanager/listener/ConnectionListener.java
@@ -22,6 +22,7 @@
 package org.ironjacamar.core.connectionmanager.listener;
 
 import org.ironjacamar.core.connectionmanager.Credential;
+import org.ironjacamar.core.connectionmanager.pool.ManagedConnectionPool;
 
 import java.util.Set;
 
@@ -97,6 +98,18 @@ public interface ConnectionListener extends org.ironjacamar.core.api.connectionm
    public void enlist() throws ResourceException;
    
    /**
+    * Delist the listener
+    * @exception ResourceException Thrown if the listener can't be delisted
+    */
+   public void delist() throws ResourceException;
+   
+   /**
+    * Get the managed connection pool
+    * @return The value
+    */
+   public ManagedConnectionPool getManagedConnectionPool();
+
+   /**
     * Get a connection
     * @return The connection
     * @exception ResourceException Thrown if a connection can't be obtained
@@ -114,6 +127,12 @@ public interface ConnectionListener extends org.ironjacamar.core.api.connectionm
     * @param c The handle
     */
    public void addConnection(Object c);
+
+   /**
+    * Remove a connection handle
+    * @param c The handle
+    */
+   public void removeConnection(Object c);
 
    /**
     * Clear all connection handles

--- a/core/src/main/java/org/ironjacamar/core/connectionmanager/listener/dflt/NoTransactionConnectionListener.java
+++ b/core/src/main/java/org/ironjacamar/core/connectionmanager/listener/dflt/NoTransactionConnectionListener.java
@@ -65,4 +65,11 @@ public class NoTransactionConnectionListener extends AbstractConnectionListener
    public void enlist() throws ResourceException
    {
    }
+
+   /**
+    * {@inheritDoc}
+    */
+   public void delist() throws ResourceException
+   {
+   }
 }

--- a/core/src/main/java/org/ironjacamar/core/connectionmanager/listener/stable/AbstractTransactionalConnectionListener.java
+++ b/core/src/main/java/org/ironjacamar/core/connectionmanager/listener/stable/AbstractTransactionalConnectionListener.java
@@ -84,6 +84,19 @@ public abstract class AbstractTransactionalConnectionListener extends
    }
 
    /**
+    * {@inheritDoc}
+    */
+   public synchronized void delist() throws ResourceException
+   {
+      if (!isEnlisted())
+      {
+         setState(DESTROY);
+      }
+
+      super.delist();
+   }
+
+   /**
     * Create the transaction synchronization object
     * @return The object
     */

--- a/core/src/main/java/org/ironjacamar/core/connectionmanager/listener/stable/NoTransactionConnectionListener.java
+++ b/core/src/main/java/org/ironjacamar/core/connectionmanager/listener/stable/NoTransactionConnectionListener.java
@@ -65,4 +65,11 @@ public class NoTransactionConnectionListener extends AbstractConnectionListener
    public void enlist() throws ResourceException
    {
    }
+
+   /**
+    * {@inheritDoc}
+    */
+   public void delist() throws ResourceException
+   {
+   }
 }

--- a/core/src/main/java/org/ironjacamar/core/connectionmanager/pool/ManagedConnectionPool.java
+++ b/core/src/main/java/org/ironjacamar/core/connectionmanager/pool/ManagedConnectionPool.java
@@ -24,6 +24,7 @@ package org.ironjacamar.core.connectionmanager.pool;
 import org.ironjacamar.core.connectionmanager.listener.ConnectionListener;
 
 import javax.resource.ResourceException;
+import javax.resource.spi.ManagedConnection;
 
 /**
  * ManagedConnectionPool
@@ -71,7 +72,8 @@ public interface ManagedConnectionPool
     */
    public void removeIdleConnections();
 
-    /** Checks if the pool is empty or not
+   /**
+    * Checks if the pool is empty or not
     * @return True if is emtpy; otherwise false
     */
    public boolean isEmpty();
@@ -82,4 +84,18 @@ public interface ManagedConnectionPool
     */
    public void flush(FlushMode mode);
 
+   /**
+    * Find a ConnectionListener instance
+    * @param mc The associated ManagedConnection
+    * @param c The connection (optional)
+    * @return The ConnectionListener, or <code>null</code>
+    */
+   public ConnectionListener findConnectionListener(ManagedConnection mc, Object c);
+
+   /**
+    * Remove a ConnectionListener instance
+    * @param free True if FREE, false if IN_USE
+    * @return The ConnectionListener, or <code>null</code>
+    */
+   public ConnectionListener removeConnectionListener(boolean free);
 }

--- a/core/src/main/java/org/ironjacamar/core/connectionmanager/pool/Pool.java
+++ b/core/src/main/java/org/ironjacamar/core/connectionmanager/pool/Pool.java
@@ -28,6 +28,7 @@ import org.ironjacamar.core.connectionmanager.Credential;
 import org.ironjacamar.core.connectionmanager.listener.ConnectionListener;
 
 import javax.resource.ResourceException;
+import javax.resource.spi.ManagedConnection;
 
 /**
  * A pool
@@ -140,4 +141,39 @@ public interface Pool extends org.ironjacamar.core.api.connectionmanager.pool.Po
     */
    public void flush(FlushMode mode);
 
+   /**
+    * Enlist
+    * @param mc The ManagedConnection
+    * @exception ResourceException Thrown in case of an error
+    */
+   public void enlist(ManagedConnection mc) throws ResourceException;
+
+   /**
+    * Delist
+    * @param cl The ConnectionListener
+    * @exception ResourceException Thrown in case of an error
+    */
+   public void delist(ConnectionListener cl) throws ResourceException;
+
+   /**
+    * Find a ConnectionListener instance
+    * @param mc The associated ManagedConnection
+    * @param c The connection (optional)
+    * @return The ConnectionListener, or <code>null</code>
+    */
+   public ConnectionListener findConnectionListener(ManagedConnection mc, Object c);
+
+   /**
+    * Get the active ConnectionListener instance
+    * @param credential The credential
+    * @return The ConnectionListener, or <code>null</code>
+    */
+   public ConnectionListener getActiveConnectionListener(Credential credential);
+
+   /**
+    * Remove a ConnectionListener instance
+    * @param credential The target credential (optional)
+    * @return The ConnectionListener, or <code>null</code>
+    */
+   public ConnectionListener removeConnectionListener(Credential credential);
 }

--- a/core/src/main/java/org/ironjacamar/core/connectionmanager/pool/SecurityActions.java
+++ b/core/src/main/java/org/ironjacamar/core/connectionmanager/pool/SecurityActions.java
@@ -21,9 +21,14 @@
 
 package org.ironjacamar.core.connectionmanager.pool;
 
+import org.ironjacamar.core.spi.security.SubjectFactory;
+
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Set;
 
+import javax.resource.spi.ManagedConnectionFactory;
+import javax.resource.spi.security.PasswordCredential;
 import javax.security.auth.Subject;
 
 /**
@@ -102,6 +107,68 @@ class SecurityActions
             }
          });
       }
+   }
+
+   /**
+    * Get a Subject instance
+    * @param subjectFactory The subject factory
+    * @param domain The domain
+    * @param mcf The ManagedConnectionFactory
+    * @return The instance
+    */
+   static Subject createSubject(final SubjectFactory subjectFactory,
+                                final String domain,
+                                final ManagedConnectionFactory mcf)
+   {
+      if (System.getSecurityManager() == null)
+      {
+         Subject subject = subjectFactory.createSubject(domain);
+         Set<PasswordCredential> s = getPasswordCredentials(subject);
+         if (s != null && s.size() > 0)
+         {
+            for (PasswordCredential pc : s)
+            {
+               pc.setManagedConnectionFactory(mcf);
+            }
+         }
+         return subject;
+      }
+
+      return AccessController.doPrivileged(new PrivilegedAction<Subject>() 
+      {
+         public Subject run()
+         {
+            Subject subject = subjectFactory.createSubject(domain);
+            Set<PasswordCredential> s = getPasswordCredentials(subject);
+            if (s != null && s.size() > 0)
+            {
+               for (PasswordCredential pc : s)
+               {
+                  pc.setManagedConnectionFactory(mcf);
+               }
+            }
+            return subject;
+         }
+      });
+   }
+
+   /**
+    * Get the PasswordCredential from the Subject
+    * @param subject The subject
+    * @return The instances
+    */
+   static Set<PasswordCredential> getPasswordCredentials(final Subject subject)
+   {
+      if (System.getSecurityManager() == null)
+         return subject.getPrivateCredentials(PasswordCredential.class);
+
+      return AccessController.doPrivileged(new PrivilegedAction<Set<PasswordCredential>>() 
+      {
+         public Set<PasswordCredential> run()
+         {
+            return subject.getPrivateCredentials(PasswordCredential.class);
+         }
+      });
    }
 
    /**

--- a/core/src/main/java/org/ironjacamar/core/connectionmanager/pool/dflt/DefaultManagedConnectionPool.java
+++ b/core/src/main/java/org/ironjacamar/core/connectionmanager/pool/dflt/DefaultManagedConnectionPool.java
@@ -33,6 +33,7 @@ import org.ironjacamar.core.connectionmanager.pool.PoolFiller;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
 import javax.resource.ResourceException;
+import javax.resource.spi.ManagedConnection;
 import javax.resource.spi.ManagedConnectionFactory;
 import javax.resource.spi.ValidatingManagedConnectionFactory;
 
@@ -463,5 +464,21 @@ public class DefaultManagedConnectionPool extends AbstractManagedConnectionPool
 
       // Trigger prefill
       prefill();
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   public ConnectionListener findConnectionListener(ManagedConnection mc, Object c)
+   {
+      return findConnectionListener(mc, c, listeners);
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   public ConnectionListener removeConnectionListener(boolean free)
+   {
+      return removeConnectionListener(free, listeners);
    }
 }

--- a/core/src/main/java/org/ironjacamar/core/connectionmanager/pool/stable/StableManagedConnectionPool.java
+++ b/core/src/main/java/org/ironjacamar/core/connectionmanager/pool/stable/StableManagedConnectionPool.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.TimeUnit;
 
 import javax.resource.ResourceException;
+import javax.resource.spi.ManagedConnection;
 import javax.resource.spi.ManagedConnectionFactory;
 import javax.resource.spi.ValidatingManagedConnectionFactory;
 
@@ -496,4 +497,19 @@ public class StableManagedConnectionPool extends AbstractManagedConnectionPool
       prefill();
    }
 
+   /**
+    * {@inheritDoc}
+    */
+   public ConnectionListener findConnectionListener(ManagedConnection mc, Object c)
+   {
+      return findConnectionListener(mc, c, listeners);
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   public ConnectionListener removeConnectionListener(boolean free)
+   {
+      return removeConnectionListener(free, listeners);
+   }
 }

--- a/deployers/src/main/java/org/ironjacamar/deployers/common/AbstractResourceAdapterDeployer.java
+++ b/deployers/src/main/java/org/ironjacamar/deployers/common/AbstractResourceAdapterDeployer.java
@@ -66,9 +66,12 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import javax.resource.spi.BootstrapContext;
 import javax.resource.spi.ResourceAdapterAssociation;
+
+import org.jboss.logging.Logger;
 
 /**
  * Base class for resource adapter deployers
@@ -76,6 +79,9 @@ import javax.resource.spi.ResourceAdapterAssociation;
  */
 public abstract class AbstractResourceAdapterDeployer
 {
+   /** The logger */
+   private static Logger log = Logger.getLogger(AbstractResourceAdapterDeployer.class);
+
    /** The DeploymentRepository */
    protected DeploymentRepository deploymentRepository;
 
@@ -225,6 +231,9 @@ public abstract class AbstractResourceAdapterDeployer
    public Deployment activate(Connector connector, Activation activation, ClassLoader cl)
       throws DeployException
    {
+      log.tracef("Connector=%s", connector);
+      log.tracef("Activation=%s", stripPassword(activation.toString()));
+
       try
       {
          DeploymentBuilder builder = new DeploymentBuilder();
@@ -1072,5 +1081,30 @@ public abstract class AbstractResourceAdapterDeployer
             return raXml.getResourceadapterVersion().getValue();
 
       return "";
+   }
+
+   /**
+    * Strip password
+    * @param str The string
+    * @return The result
+    */
+   private String stripPassword(String str)
+   {
+      if (str.indexOf("<password>") == -1)
+         return str;
+
+      Pattern pattern = Pattern.compile("<password>[^<]*</password>");
+      String[] strs = pattern.split(str);
+
+      StringBuilder sb = new StringBuilder();
+      for (int i = 0; i < strs.length; i++)
+      {
+         String s = strs[i];
+         sb.append(s);
+         if (i < strs.length - 1)
+            sb.append("<password>****</password>");
+      }
+
+      return sb.toString();
    }
 }

--- a/testsuite/src/test/java/org/ironjacamar/core/connectionmanager/lazy/LazyCCMLocalTransactionTestCase.java
+++ b/testsuite/src/test/java/org/ironjacamar/core/connectionmanager/lazy/LazyCCMLocalTransactionTestCase.java
@@ -1,0 +1,291 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.ironjacamar.core.connectionmanager.lazy;
+
+import org.ironjacamar.embedded.Configuration;
+import org.ironjacamar.embedded.Deployment;
+import org.ironjacamar.embedded.junit4.AllChecks;
+import org.ironjacamar.embedded.junit4.IronJacamar;
+import org.ironjacamar.embedded.junit4.PostCondition;
+import org.ironjacamar.embedded.junit4.PreCondition;
+import org.ironjacamar.rars.ResourceAdapterFactory;
+import org.ironjacamar.rars.lazy.LazyConnection;
+import org.ironjacamar.rars.lazy.LazyConnectionFactory;
+
+import java.util.concurrent.CountDownLatch;
+
+import javax.annotation.Resource;
+import javax.resource.spi.TransactionSupport.TransactionSupportLevel;
+import javax.transaction.UserTransaction;
+
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test cases for deploying a lazy association resource adapter archive
+ * using multiple threads (LocalTransaction) (CCM)
+ *
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ */
+@RunWith(IronJacamar.class)
+@Configuration(full = true)
+@PreCondition(condition = AllChecks.class)
+@PostCondition(condition = AllChecks.class)
+public class LazyCCMLocalTransactionTestCase
+{
+   /** The logger */
+   private static Logger log = Logger.getLogger(LazyCCMLocalTransactionTestCase.class);
+
+   /**
+    * Define the deployment
+    * @return The deployment archive
+    * @throws Exception in case of errors
+    */
+   @Deployment(order = 1)
+   public static ResourceAdapterArchive createDeployment() throws Exception
+   {
+      return ResourceAdapterFactory.createLazyRar();
+   }
+
+   /**
+    * Define the deployment
+    * @return The deployment archive
+    * @throws Exception in case of errors
+    */
+   @Deployment(order = 2)
+   public static Descriptor createDescriptor() throws Exception
+   {
+      return ResourceAdapterFactory.createLazyDeployment(TransactionSupportLevel.LocalTransaction);
+   }
+
+   @Resource(mappedName = "java:/eis/LazyConnectionFactory")
+   private LazyConnectionFactory connectionFactory;
+
+   @Resource(mappedName = "java:/UserTransaction")
+   private UserTransaction userTransaction;
+
+   /**
+    * CCM
+    * @exception Throwable Thrown if case of an error
+    */
+   @Test
+   public void testCCM() throws Throwable
+   {
+      assertNotNull(connectionFactory);
+      assertNotNull(userTransaction);
+
+      CountDownLatch step1 = new CountDownLatch(1);
+      CountDownLatch step2 = new CountDownLatch(1);
+      CountDownLatch step3 = new CountDownLatch(1);
+      CountDownLatch step4 = new CountDownLatch(1);
+      CountDownLatch done = new CountDownLatch(2);
+
+      Worker primary = new Worker(connectionFactory, userTransaction, true, true, step1, step2, step3, step4, done);
+      Thread t1 = new Thread(primary);
+      t1.start();
+
+      Worker secondary = new Worker(connectionFactory, userTransaction, true, false, step1, step2, step3, step4, done);
+      Thread t2 = new Thread(secondary);
+      t2.start();
+
+      done.await();
+
+      assertNull(primary.getThrowable());
+      assertNull(secondary.getThrowable());
+   }
+
+   /**
+    * Worker
+    */
+   private static class Worker implements Runnable
+   {
+      /** Throwable */
+      private Throwable throwable;
+
+      /** CF */
+      private LazyConnectionFactory connectionFactory;
+
+      /** UT */
+      private UserTransaction userTransaction;
+
+      /** Enlist */
+      private boolean enlist;
+
+      /** Primary */
+      private boolean primary;
+
+      /** Step1 */
+      private CountDownLatch step1;
+
+      /** Step2 */
+      private CountDownLatch step2;
+
+      /** Step3 */
+      private CountDownLatch step3;
+
+      /** Step4 */
+      private CountDownLatch step4;
+
+      /** Done */
+      private CountDownLatch done;
+
+      /**
+       * Constructor
+       * @param connectionFactory The CF
+       * @param userTransaction The UT
+       * @param enlist Enlistment
+       * @param primary Primary worker
+       * @param step1 Step 1 trigger
+       * @param step2 Step 2 trigger
+       * @param step3 Step 3 trigger
+       * @param step4 Step 4 trigger
+       * @param done Done trigger
+       */
+      public Worker(LazyConnectionFactory connectionFactory, UserTransaction userTransaction,
+                    boolean enlist, boolean primary,
+                    CountDownLatch step1, CountDownLatch step2, CountDownLatch step3, CountDownLatch step4,
+                    CountDownLatch done)
+      {
+         this.throwable = null;
+         this.connectionFactory = connectionFactory;
+         this.userTransaction = userTransaction;
+         this.enlist = enlist;
+         this.primary = primary;
+         this.step1 = step1;
+         this.step2 = step2;
+         this.step3 = step3;
+         this.step4 = step4;
+         this.done = done;
+      }
+
+      /**
+       * Get throwable
+       * @return The value
+       */
+      public Throwable getThrowable()
+      {
+         return throwable;
+      }
+
+      /**
+       * {@inheritDoc}
+       */
+      public void run()
+      {
+         LazyConnection lc = null;
+         boolean status = true;
+         try
+         {
+            if (!primary)
+            {
+               step1.await();
+               log.info("Step2");
+            }
+            else
+            {
+               log.info("Step1");
+            }
+
+            if (primary)
+            {
+               lc = connectionFactory.getConnection();
+               assertTrue(lc.isManagedConnectionSet());
+
+               userTransaction.begin();
+               
+               step1.countDown();
+               step2.await();
+               log.info("Step3");
+            }
+            else
+            {
+               try
+               {
+                  lc = connectionFactory.getConnection();
+                  fail("Got a connection");
+               }
+               catch (Exception e)
+               {
+                  userTransaction.begin();
+                  step2.countDown();
+               }
+            }
+
+            if (primary)
+            {
+               if (enlist)
+               {
+                  assertFalse(lc.isEnlisted());
+                  assertTrue(lc.enlist());
+                  assertTrue(lc.isEnlisted());
+               }
+
+               step3.countDown();
+               step4.await();
+            }
+            else
+            {
+               step3.await();
+               log.info("Step4");
+               assertNull(lc);
+               step4.countDown();
+            }
+         }
+         catch (Exception e)
+         {
+            log.error(e.getMessage(), e);
+            throwable = e;
+            status = false;
+         }
+         finally
+         {
+            if (lc != null)
+               lc.close();
+
+            try
+            {
+               if (status)
+               {
+                  userTransaction.commit();
+               }
+               else
+               {
+                  userTransaction.rollback();
+               }
+            }
+            catch (Exception e)
+            {
+               log.error(e.getMessage(), e);
+               throwable = e;
+            }
+
+            done.countDown();
+         }
+      }
+   }
+}

--- a/testsuite/src/test/java/org/ironjacamar/core/connectionmanager/lazy/LazyCCMNoTransactionTestCase.java
+++ b/testsuite/src/test/java/org/ironjacamar/core/connectionmanager/lazy/LazyCCMNoTransactionTestCase.java
@@ -1,0 +1,243 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.ironjacamar.core.connectionmanager.lazy;
+
+import org.ironjacamar.embedded.Configuration;
+import org.ironjacamar.embedded.Deployment;
+import org.ironjacamar.embedded.junit4.AllChecks;
+import org.ironjacamar.embedded.junit4.IronJacamar;
+import org.ironjacamar.embedded.junit4.PostCondition;
+import org.ironjacamar.embedded.junit4.PreCondition;
+import org.ironjacamar.rars.ResourceAdapterFactory;
+import org.ironjacamar.rars.lazy.LazyConnection;
+import org.ironjacamar.rars.lazy.LazyConnectionFactory;
+
+import java.util.concurrent.CountDownLatch;
+
+import javax.annotation.Resource;
+import javax.resource.spi.TransactionSupport.TransactionSupportLevel;
+import javax.transaction.UserTransaction;
+
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test cases for deploying a lazy association resource adapter archive
+ * using multiple threads (CCM)
+ *
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ */
+@RunWith(IronJacamar.class)
+@Configuration(full = true)
+@PreCondition(condition = AllChecks.class)
+@PostCondition(condition = AllChecks.class)
+public class LazyCCMNoTransactionTestCase
+{
+   /** The logger */
+   private static Logger log = Logger.getLogger(LazyCCMNoTransactionTestCase.class);
+
+   /**
+    * Define the deployment
+    * @return The deployment archive
+    * @throws Exception in case of errors
+    */
+   @Deployment(order = 1)
+   public static ResourceAdapterArchive createDeployment() throws Exception
+   {
+      return ResourceAdapterFactory.createLazyRar();
+   }
+
+   /**
+    * Define the deployment
+    * @return The deployment archive
+    * @throws Exception in case of errors
+    */
+   @Deployment(order = 2)
+   public static Descriptor createDescriptor() throws Exception
+   {
+      return ResourceAdapterFactory.createLazyDeployment(TransactionSupportLevel.NoTransaction);
+   }
+
+   @Resource(mappedName = "java:/eis/LazyConnectionFactory")
+   private LazyConnectionFactory connectionFactory;
+
+   @Resource(mappedName = "java:/UserTransaction")
+   private UserTransaction userTransaction;
+
+   /**
+    * CCM
+    * @exception Throwable Thrown if case of an error
+    */
+   @Test
+   public void testCCM() throws Throwable
+   {
+      assertNotNull(connectionFactory);
+
+      CountDownLatch step1 = new CountDownLatch(1);
+      CountDownLatch step2 = new CountDownLatch(1);
+      CountDownLatch done = new CountDownLatch(2);
+
+      Worker primary = new Worker(connectionFactory, true, userTransaction, step1, step2, done);
+      Thread t1 = new Thread(primary);
+      t1.start();
+
+      Worker secondary = new Worker(connectionFactory, false, userTransaction, step1, step2, done);
+      Thread t2 = new Thread(secondary);
+      t2.start();
+
+      done.await();
+
+      assertNull(primary.getThrowable());
+      assertNull(secondary.getThrowable());
+   }
+
+   /**
+    * Worker
+    */
+   private static class Worker implements Runnable
+   {
+      /** Throwable */
+      private Throwable throwable;
+
+      /** CF */
+      private LazyConnectionFactory connectionFactory;
+
+      /** Primary */
+      private boolean primary;
+
+      /** UserTransaction */
+      private UserTransaction ut;
+
+      /** Step1 */
+      private CountDownLatch step1;
+
+      /** Step2 */
+      private CountDownLatch step2;
+
+      /** Done */
+      private CountDownLatch done;
+
+      /**
+       * Constructor
+       * @param connectionFactory The CF
+       * @param primary Primary worker
+       * @param ut The user transaction
+       * @param step1 Step 1 trigger
+       * @param step2 Step 2 trigger
+       * @param done Done trigger
+       */
+      public Worker(LazyConnectionFactory connectionFactory, boolean primary,
+                    UserTransaction ut,
+                    CountDownLatch step1, CountDownLatch step2, CountDownLatch done)
+      {
+         this.throwable = null;
+         this.connectionFactory = connectionFactory;
+         this.primary = primary;
+         this.ut = ut;
+         this.step1 = step1;
+         this.step2 = step2;
+         this.done = done;
+      }
+
+      /**
+       * Get throwable
+       * @return The value
+       */
+      public Throwable getThrowable()
+      {
+         return throwable;
+      }
+
+      /**
+       * {@inheritDoc}
+       */
+      public void run()
+      {
+         LazyConnection lc = null;
+         try
+         {
+            if (!primary)
+            {
+               step1.await();
+               log.info("Step2");
+            }
+            else
+            {
+               log.info("Step1");
+            }
+
+            lc = connectionFactory.getConnection();
+            
+            ut.begin();
+
+            assertTrue(lc.isManagedConnectionSet());
+
+            if (primary)
+            {
+               step1.countDown();
+               step2.await();
+               log.info("Step3");
+            }
+            else
+            {
+               assertTrue(lc.closeManagedConnection());
+               step2.countDown();
+            }
+
+            assertFalse(lc.isManagedConnectionSet());
+
+            if (primary)
+            {
+               assertTrue(lc.associate());
+               assertTrue(lc.isManagedConnectionSet());
+            }
+         }
+         catch (Throwable t)
+         {
+            t.printStackTrace();
+            throwable = t;
+         }
+         finally
+         {
+            if (lc != null)
+               lc.close();
+
+            try
+            {
+               ut.commit();
+            }
+            catch (Throwable t)
+            {
+               throwable = t;
+            }
+            
+            done.countDown();
+         }
+      }
+   }
+}

--- a/testsuite/src/test/java/org/ironjacamar/core/connectionmanager/lazy/LazyCCMXATransactionTestCase.java
+++ b/testsuite/src/test/java/org/ironjacamar/core/connectionmanager/lazy/LazyCCMXATransactionTestCase.java
@@ -1,0 +1,291 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.ironjacamar.core.connectionmanager.lazy;
+
+import org.ironjacamar.embedded.Configuration;
+import org.ironjacamar.embedded.Deployment;
+import org.ironjacamar.embedded.junit4.AllChecks;
+import org.ironjacamar.embedded.junit4.IronJacamar;
+import org.ironjacamar.embedded.junit4.PostCondition;
+import org.ironjacamar.embedded.junit4.PreCondition;
+import org.ironjacamar.rars.ResourceAdapterFactory;
+import org.ironjacamar.rars.lazy.LazyConnection;
+import org.ironjacamar.rars.lazy.LazyConnectionFactory;
+
+import java.util.concurrent.CountDownLatch;
+
+import javax.annotation.Resource;
+import javax.resource.spi.TransactionSupport.TransactionSupportLevel;
+import javax.transaction.UserTransaction;
+
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test cases for deploying a lazy association resource adapter archive
+ * using multiple threads (XATransaction) (CCM)
+ *
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ */
+@RunWith(IronJacamar.class)
+@Configuration(full = true)
+@PreCondition(condition = AllChecks.class)
+@PostCondition(condition = AllChecks.class)
+public class LazyCCMXATransactionTestCase
+{
+   /** The logger */
+   private static Logger log = Logger.getLogger(LazyCCMXATransactionTestCase.class);
+
+   /**
+    * Define the deployment
+    * @return The deployment archive
+    * @throws Exception in case of errors
+    */
+   @Deployment(order = 1)
+   public static ResourceAdapterArchive createDeployment() throws Exception
+   {
+      return ResourceAdapterFactory.createLazyRar();
+   }
+
+   /**
+    * Define the deployment
+    * @return The deployment archive
+    * @throws Exception in case of errors
+    */
+   @Deployment(order = 2)
+   public static Descriptor createDescriptor() throws Exception
+   {
+      return ResourceAdapterFactory.createLazyDeployment(TransactionSupportLevel.XATransaction);
+   }
+
+   @Resource(mappedName = "java:/eis/LazyConnectionFactory")
+   private LazyConnectionFactory connectionFactory;
+
+   @Resource(mappedName = "java:/UserTransaction")
+   private UserTransaction userTransaction;
+
+   /**
+    * CCM
+    * @exception Throwable Thrown if case of an error
+    */
+   @Test
+   public void testCCM() throws Throwable
+   {
+      assertNotNull(connectionFactory);
+      assertNotNull(userTransaction);
+
+      CountDownLatch step1 = new CountDownLatch(1);
+      CountDownLatch step2 = new CountDownLatch(1);
+      CountDownLatch step3 = new CountDownLatch(1);
+      CountDownLatch step4 = new CountDownLatch(1);
+      CountDownLatch done = new CountDownLatch(2);
+
+      Worker primary = new Worker(connectionFactory, userTransaction, true, true, step1, step2, step3, step4, done);
+      Thread t1 = new Thread(primary);
+      t1.start();
+
+      Worker secondary = new Worker(connectionFactory, userTransaction, true, false, step1, step2, step3, step4, done);
+      Thread t2 = new Thread(secondary);
+      t2.start();
+
+      done.await();
+
+      assertNull(primary.getThrowable());
+      assertNull(secondary.getThrowable());
+   }
+
+   /**
+    * Worker
+    */
+   private static class Worker implements Runnable
+   {
+      /** Throwable */
+      private Throwable throwable;
+
+      /** CF */
+      private LazyConnectionFactory connectionFactory;
+
+      /** UT */
+      private UserTransaction userTransaction;
+
+      /** Enlist */
+      private boolean enlist;
+
+      /** Primary */
+      private boolean primary;
+
+      /** Step1 */
+      private CountDownLatch step1;
+
+      /** Step2 */
+      private CountDownLatch step2;
+
+      /** Step3 */
+      private CountDownLatch step3;
+
+      /** Step4 */
+      private CountDownLatch step4;
+
+      /** Done */
+      private CountDownLatch done;
+
+      /**
+       * Constructor
+       * @param connectionFactory The CF
+       * @param userTransaction The UT
+       * @param enlist Enlistment
+       * @param primary Primary worker
+       * @param step1 Step 1 trigger
+       * @param step2 Step 2 trigger
+       * @param step3 Step 3 trigger
+       * @param step4 Step 4 trigger
+       * @param done Done trigger
+       */
+      public Worker(LazyConnectionFactory connectionFactory, UserTransaction userTransaction,
+                    boolean enlist, boolean primary,
+                    CountDownLatch step1, CountDownLatch step2, CountDownLatch step3, CountDownLatch step4,
+                    CountDownLatch done)
+      {
+         this.throwable = null;
+         this.connectionFactory = connectionFactory;
+         this.userTransaction = userTransaction;
+         this.enlist = enlist;
+         this.primary = primary;
+         this.step1 = step1;
+         this.step2 = step2;
+         this.step3 = step3;
+         this.step4 = step4;
+         this.done = done;
+      }
+
+      /**
+       * Get throwable
+       * @return The value
+       */
+      public Throwable getThrowable()
+      {
+         return throwable;
+      }
+
+      /**
+       * {@inheritDoc}
+       */
+      public void run()
+      {
+         LazyConnection lc = null;
+         boolean status = true;
+         try
+         {
+            if (!primary)
+            {
+               step1.await();
+               log.info("Step2");
+            }
+            else
+            {
+               log.info("Step1");
+            }
+
+            if (primary)
+            {
+               lc = connectionFactory.getConnection();
+               assertTrue(lc.isManagedConnectionSet());
+
+               userTransaction.begin();
+
+               step1.countDown();
+               step2.await();
+               log.info("Step3");
+            }
+            else
+            {
+               try
+               {
+                  lc = connectionFactory.getConnection();
+                  fail("Got a connection");
+               }
+               catch (Exception e)
+               {
+                  userTransaction.begin();
+                  step2.countDown();
+               }
+            }
+
+            if (primary)
+            {
+               if (enlist)
+               {
+                  assertFalse(lc.isEnlisted());
+                  assertTrue(lc.enlist());
+                  assertTrue(lc.isEnlisted());
+               }
+
+               step3.countDown();
+               step4.await();
+            }
+            else
+            {
+               step3.await();
+               log.info("Step4");
+               assertNull(lc);
+               step4.countDown();
+            }
+         }
+         catch (Exception e)
+         {
+            log.error(e.getMessage(), e);
+            throwable = e;
+            status = false;
+         }
+         finally
+         {
+            if (lc != null)
+               lc.close();
+
+            try
+            {
+               if (status)
+               {
+                  userTransaction.commit();
+               }
+               else
+               {
+                  userTransaction.rollback();
+               }
+            }
+            catch (Exception e)
+            {
+               log.error(e.getMessage(), e);
+               throwable = e;
+            }
+
+            done.countDown();
+         }
+      }
+   }
+}

--- a/testsuite/src/test/java/org/ironjacamar/core/connectionmanager/lazy/LazyLocalTransactionMTTestCase.java
+++ b/testsuite/src/test/java/org/ironjacamar/core/connectionmanager/lazy/LazyLocalTransactionMTTestCase.java
@@ -1,0 +1,320 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.ironjacamar.core.connectionmanager.lazy;
+
+import org.ironjacamar.embedded.Configuration;
+import org.ironjacamar.embedded.Deployment;
+import org.ironjacamar.embedded.junit4.AllChecks;
+import org.ironjacamar.embedded.junit4.IronJacamar;
+import org.ironjacamar.embedded.junit4.PostCondition;
+import org.ironjacamar.embedded.junit4.PreCondition;
+import org.ironjacamar.rars.ResourceAdapterFactory;
+import org.ironjacamar.rars.lazy.LazyConnection;
+import org.ironjacamar.rars.lazy.LazyConnectionFactory;
+
+import java.util.concurrent.CountDownLatch;
+
+import javax.annotation.Resource;
+import javax.resource.spi.TransactionSupport.TransactionSupportLevel;
+import javax.transaction.UserTransaction;
+
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test cases for deploying a lazy association resource adapter archive
+ * using multiple threads (LocalTransaction)
+ *
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ */
+@RunWith(IronJacamar.class)
+@Configuration(full = true)
+@PreCondition(condition = AllChecks.class)
+@PostCondition(condition = AllChecks.class)
+public class LazyLocalTransactionMTTestCase
+{
+   /** The logger */
+   private static Logger log = Logger.getLogger(LazyLocalTransactionMTTestCase.class);
+
+   /**
+    * Define the deployment
+    * @return The deployment archive
+    * @throws Exception in case of errors
+    */
+   @Deployment(order = 1)
+   public static ResourceAdapterArchive createDeployment() throws Exception
+   {
+      return ResourceAdapterFactory.createLazyRar();
+   }
+
+   /**
+    * Define the deployment
+    * @return The deployment archive
+    * @throws Exception in case of errors
+    */
+   @Deployment(order = 2)
+   public static Descriptor createDescriptor() throws Exception
+   {
+      return ResourceAdapterFactory.createLazyDeployment(TransactionSupportLevel.LocalTransaction);
+   }
+
+   @Resource(mappedName = "java:/eis/LazyConnectionFactory")
+   private LazyConnectionFactory connectionFactory;
+
+   @Resource(mappedName = "java:/UserTransaction")
+   private UserTransaction userTransaction;
+
+   /**
+    * Two connections - one managed connection - without enlistment
+    * @exception Throwable Thrown if case of an error
+    */
+   @Test
+   public void testTwoConnectionsWithoutEnlistment() throws Throwable
+   {
+      assertNotNull(connectionFactory);
+      assertNotNull(userTransaction);
+
+      CountDownLatch step1 = new CountDownLatch(1);
+      CountDownLatch step2 = new CountDownLatch(1);
+      CountDownLatch step3 = new CountDownLatch(1);
+      CountDownLatch step4 = new CountDownLatch(1);
+      CountDownLatch done = new CountDownLatch(2);
+
+      Worker primary = new Worker(connectionFactory, userTransaction, false, true, step1, step2, step3, step4, done);
+      Thread t1 = new Thread(primary);
+      t1.start();
+
+      Worker secondary = new Worker(connectionFactory, userTransaction, false, false, step1, step2, step3, step4, done);
+      Thread t2 = new Thread(secondary);
+      t2.start();
+
+      done.await();
+
+      assertNull(primary.getThrowable());
+      assertNull(secondary.getThrowable());
+   }
+
+   /**
+    * Two connections - one managed connection - with enlistment
+    * @exception Throwable Thrown if case of an error
+    */
+   @Test
+   public void testTwoConnectionsWithEnlistment() throws Throwable
+   {
+      assertNotNull(connectionFactory);
+      assertNotNull(userTransaction);
+
+      CountDownLatch step1 = new CountDownLatch(1);
+      CountDownLatch step2 = new CountDownLatch(1);
+      CountDownLatch step3 = new CountDownLatch(1);
+      CountDownLatch step4 = new CountDownLatch(1);
+      CountDownLatch done = new CountDownLatch(2);
+
+      Worker primary = new Worker(connectionFactory, userTransaction, true, true, step1, step2, step3, step4, done);
+      Thread t1 = new Thread(primary);
+      t1.start();
+
+      Worker secondary = new Worker(connectionFactory, userTransaction, true, false, step1, step2, step3, step4, done);
+      Thread t2 = new Thread(secondary);
+      t2.start();
+
+      done.await();
+
+      assertNull(primary.getThrowable());
+      assertNull(secondary.getThrowable());
+   }
+
+   /**
+    * Worker
+    */
+   private static class Worker implements Runnable
+   {
+      /** Throwable */
+      private Throwable throwable;
+
+      /** CF */
+      private LazyConnectionFactory connectionFactory;
+
+      /** UT */
+      private UserTransaction userTransaction;
+
+      /** Enlist */
+      private boolean enlist;
+
+      /** Primary */
+      private boolean primary;
+
+      /** Step1 */
+      private CountDownLatch step1;
+
+      /** Step2 */
+      private CountDownLatch step2;
+
+      /** Step3 */
+      private CountDownLatch step3;
+
+      /** Step4 */
+      private CountDownLatch step4;
+
+      /** Done */
+      private CountDownLatch done;
+
+      /**
+       * Constructor
+       * @param connectionFactory The CF
+       * @param userTransaction The UT
+       * @param enlist Enlistment
+       * @param primary Primary worker
+       * @param step1 Step 1 trigger
+       * @param step2 Step 2 trigger
+       * @param step3 Step 3 trigger
+       * @param step4 Step 4 trigger
+       * @param done Done trigger
+       */
+      public Worker(LazyConnectionFactory connectionFactory, UserTransaction userTransaction,
+                    boolean enlist, boolean primary,
+                    CountDownLatch step1, CountDownLatch step2, CountDownLatch step3, CountDownLatch step4,
+                    CountDownLatch done)
+      {
+         this.throwable = null;
+         this.connectionFactory = connectionFactory;
+         this.userTransaction = userTransaction;
+         this.enlist = enlist;
+         this.primary = primary;
+         this.step1 = step1;
+         this.step2 = step2;
+         this.step3 = step3;
+         this.step4 = step4;
+         this.done = done;
+      }
+
+      /**
+       * Get throwable
+       * @return The value
+       */
+      public Throwable getThrowable()
+      {
+         return throwable;
+      }
+
+      /**
+       * {@inheritDoc}
+       */
+      public void run()
+      {
+         LazyConnection lc = null;
+         boolean status = true;
+         try
+         {
+            userTransaction.begin();
+
+            if (!primary)
+            {
+               step1.await();
+               log.info("Step2");
+            }
+            else
+            {
+               log.info("Step1");
+            }
+
+            if (primary)
+            {
+               lc = connectionFactory.getConnection();
+               assertTrue(lc.isManagedConnectionSet());
+
+               step1.countDown();
+               step2.await();
+               log.info("Step3");
+            }
+            else
+            {
+               try
+               {
+                  lc = connectionFactory.getConnection();
+                  fail("Got a connection");
+               }
+               catch (Exception e)
+               {
+                  step2.countDown();
+               }
+            }
+
+            if (primary)
+            {
+               if (enlist)
+               {
+                  assertFalse(lc.isEnlisted());
+                  assertTrue(lc.enlist());
+                  assertTrue(lc.isEnlisted());
+               }
+
+               step3.countDown();
+               step4.await();
+            }
+            else
+            {
+               step3.await();
+               log.info("Step4");
+               assertNull(lc);
+               step4.countDown();
+            }
+         }
+         catch (Exception e)
+         {
+            log.error(e.getMessage(), e);
+            throwable = e;
+            status = false;
+         }
+         finally
+         {
+            if (lc != null)
+               lc.close();
+
+            try
+            {
+               if (status)
+               {
+                  userTransaction.commit();
+               }
+               else
+               {
+                  userTransaction.rollback();
+               }
+            }
+            catch (Exception e)
+            {
+               log.error(e.getMessage(), e);
+               throwable = e;
+            }
+
+            done.countDown();
+         }
+      }
+   }
+}

--- a/testsuite/src/test/java/org/ironjacamar/core/connectionmanager/lazy/LazyLocalTransactionTestCase.java
+++ b/testsuite/src/test/java/org/ironjacamar/core/connectionmanager/lazy/LazyLocalTransactionTestCase.java
@@ -1,0 +1,286 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.ironjacamar.core.connectionmanager.lazy;
+
+import org.ironjacamar.embedded.Configuration;
+import org.ironjacamar.embedded.Deployment;
+import org.ironjacamar.embedded.junit4.AllChecks;
+import org.ironjacamar.embedded.junit4.IronJacamar;
+import org.ironjacamar.embedded.junit4.PostCondition;
+import org.ironjacamar.embedded.junit4.PreCondition;
+import org.ironjacamar.rars.ResourceAdapterFactory;
+import org.ironjacamar.rars.lazy.LazyConnection;
+import org.ironjacamar.rars.lazy.LazyConnectionFactory;
+
+import javax.annotation.Resource;
+import javax.resource.spi.TransactionSupport.TransactionSupportLevel;
+import javax.transaction.UserTransaction;
+
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test cases for deploying a lazy association resource adapter archive using LocalTransaction
+ *
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ */
+@RunWith(IronJacamar.class)
+@Configuration(full = true)
+@PreCondition(condition = AllChecks.class)
+@PostCondition(condition = AllChecks.class)
+public class LazyLocalTransactionTestCase
+{
+   private static Logger log = Logger.getLogger(LazyLocalTransactionTestCase.class);
+
+   /**
+    * Define the deployment
+    * @return The deployment archive
+    * @throws Exception in case of errors
+    */
+   @Deployment(order = 1)
+   public static ResourceAdapterArchive createDeployment() throws Exception
+   {
+      return ResourceAdapterFactory.createLazyRar();
+   }
+
+   /**
+    * Define the deployment
+    * @return The deployment archive
+    * @throws Exception in case of errors
+    */
+   @Deployment(order = 2)
+   public static Descriptor createDescriptor() throws Exception
+   {
+      return ResourceAdapterFactory.createLazyDeployment(TransactionSupportLevel.LocalTransaction);
+   }
+
+   @Resource(mappedName = "java:/eis/LazyConnectionFactory")
+   private LazyConnectionFactory connectionFactory;
+
+   @Resource(mappedName = "java:/UserTransaction")
+   private UserTransaction userTransaction;
+
+   /**
+    * Basic
+    * @exception Throwable Thrown if case of an error
+    */
+   @Test
+   public void testBasic() throws Throwable
+   {
+      log.infof("testBasic: Start");
+
+      assertNotNull(connectionFactory);
+      assertNotNull(userTransaction);
+
+      boolean status = true;
+      userTransaction.begin();
+
+      LazyConnection lc = null;
+      try
+      {
+         lc = connectionFactory.getConnection();
+
+         assertTrue(lc.isManagedConnectionSet());
+
+         assertTrue(lc.closeManagedConnection());
+
+         assertFalse(lc.isManagedConnectionSet());
+
+         assertTrue(lc.associate());
+
+         assertTrue(lc.isManagedConnectionSet());
+
+         assertFalse(lc.isEnlisted());
+         assertTrue(lc.enlist());
+         assertTrue(lc.isEnlisted());
+      }
+      catch (Throwable t)
+      {
+         log.error(t.getMessage(), t);
+         status = false;
+         fail("Throwable:" + t.getMessage());
+      }
+      finally
+      {
+         if (lc != null)
+            lc.close();
+
+         if (status)
+         {
+            userTransaction.commit();
+         }
+         else
+         {
+            userTransaction.rollback();
+         }
+
+         log.infof("testBasic: End");
+      }
+   }
+
+   /**
+    * Two connections - one managed connection - without enlistment
+    * @exception Throwable Thrown if case of an error
+    */
+   @Test
+   public void testTwoConnectionsWithoutEnlistment() throws Throwable
+   {
+      log.infof("testTwoConnectionsWithoutEnlistment: Start");
+
+      assertNotNull(connectionFactory);
+      assertNotNull(userTransaction);
+
+      boolean status = true;
+      userTransaction.begin();
+
+      LazyConnection lc1 = null;
+      LazyConnection lc2 = null;
+      try
+      {
+         lc1 = connectionFactory.getConnection();
+
+         assertTrue(lc1.isManagedConnectionSet());
+
+         log.infof("testTwoConnectionsWithoutEnlistment: Before 2nd getConnection");
+
+         lc2 = connectionFactory.getConnection();
+
+         assertTrue(lc2.isManagedConnectionSet());
+         assertFalse(lc1.isManagedConnectionSet());
+
+         log.infof("testTwoConnectionsWithoutEnlistment: Before closeManagedConnection");
+
+         assertTrue(lc2.closeManagedConnection());
+
+         assertFalse(lc1.isManagedConnectionSet());
+         assertFalse(lc2.isManagedConnectionSet());
+
+         log.infof("testTwoConnectionsWithoutEnlistment: Before associate");
+
+         assertTrue(lc1.associate());
+
+         assertTrue(lc1.isManagedConnectionSet());
+         assertFalse(lc2.isManagedConnectionSet());
+
+         log.infof("testTwoConnectionsWithoutEnlistment: After associate");
+      }
+      catch (Throwable t)
+      {
+         log.error(t.getMessage(), t);
+         status = false;
+         fail("Throwable:" + t.getMessage());
+      }
+      finally
+      {
+         if (lc1 != null)
+            lc1.close();
+
+         if (lc2 != null)
+            lc2.close();
+
+         if (status)
+         {
+            userTransaction.commit();
+         }
+         else
+         {
+            userTransaction.rollback();
+         }
+
+         log.infof("testTwoConnectionsWithoutEnlistment: End");
+      }
+   }
+
+   /**
+    * Two connections - one managed connection - with enlistment
+    * @exception Throwable Thrown if case of an error
+    */
+   @Test
+   public void testTwoConnectionsWithEnlistment() throws Throwable
+   {
+      log.infof("testTwoConnectionsWithEnlistment: Start");
+
+      assertNotNull(connectionFactory);
+      assertNotNull(userTransaction);
+
+      boolean status = true;
+      userTransaction.begin();
+
+      LazyConnection lc1 = null;
+      LazyConnection lc2 = null;
+      try
+      {
+         lc1 = connectionFactory.getConnection();
+
+         assertTrue(lc1.isManagedConnectionSet());
+         assertFalse(lc1.isEnlisted());
+         assertTrue(lc1.enlist());
+         assertTrue(lc1.isEnlisted());
+
+         lc2 = connectionFactory.getConnection();
+
+         assertTrue(lc2.isManagedConnectionSet());
+         assertFalse(lc1.isManagedConnectionSet());
+
+         assertTrue(lc2.closeManagedConnection());
+
+         assertFalse(lc1.isManagedConnectionSet());
+         assertFalse(lc2.isManagedConnectionSet());
+
+         assertTrue(lc1.associate());
+
+         assertTrue(lc1.isManagedConnectionSet());
+         assertFalse(lc2.isManagedConnectionSet());
+      }
+      catch (Throwable t)
+      {
+         log.error(t.getMessage(), t);
+         status = false;
+         fail("Throwable:" + t.getMessage());
+      }
+      finally
+      {
+         if (lc1 != null)
+            lc1.close();
+
+         if (lc2 != null)
+            lc2.close();
+
+         if (status)
+         {
+            userTransaction.commit();
+         }
+         else
+         {
+            userTransaction.rollback();
+         }
+
+         log.infof("testTwoConnectionsWithEnlistment: End");
+      }
+   }
+}

--- a/testsuite/src/test/java/org/ironjacamar/core/connectionmanager/lazy/LazyNoTransactionMTTestCase.java
+++ b/testsuite/src/test/java/org/ironjacamar/core/connectionmanager/lazy/LazyNoTransactionMTTestCase.java
@@ -1,0 +1,222 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.ironjacamar.core.connectionmanager.lazy;
+
+import org.ironjacamar.embedded.Configuration;
+import org.ironjacamar.embedded.Deployment;
+import org.ironjacamar.embedded.junit4.AllChecks;
+import org.ironjacamar.embedded.junit4.IronJacamar;
+import org.ironjacamar.embedded.junit4.PostCondition;
+import org.ironjacamar.embedded.junit4.PreCondition;
+import org.ironjacamar.rars.ResourceAdapterFactory;
+import org.ironjacamar.rars.lazy.LazyConnection;
+import org.ironjacamar.rars.lazy.LazyConnectionFactory;
+
+import java.util.concurrent.CountDownLatch;
+
+import javax.annotation.Resource;
+import javax.resource.spi.TransactionSupport.TransactionSupportLevel;
+
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test cases for deploying a lazy association resource adapter archive
+ * using multiple threads
+ *
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ */
+@RunWith(IronJacamar.class)
+@Configuration(full = true)
+@PreCondition(condition = AllChecks.class)
+@PostCondition(condition = AllChecks.class)
+public class LazyNoTransactionMTTestCase
+{
+   /** The logger */
+   private static Logger log = Logger.getLogger(LazyNoTransactionMTTestCase.class);
+
+   /**
+    * Define the deployment
+    * @return The deployment archive
+    * @throws Exception in case of errors
+    */
+   @Deployment(order = 1)
+   public static ResourceAdapterArchive createDeployment() throws Exception
+   {
+      return ResourceAdapterFactory.createLazyRar();
+   }
+
+   /**
+    * Define the deployment
+    * @return The deployment archive
+    * @throws Exception in case of errors
+    */
+   @Deployment(order = 2)
+   public static Descriptor createDescriptor() throws Exception
+   {
+      return ResourceAdapterFactory.createLazyDeployment(TransactionSupportLevel.NoTransaction);
+   }
+
+   @Resource(mappedName = "java:/eis/LazyConnectionFactory")
+   private LazyConnectionFactory connectionFactory;
+
+   /**
+    * Two connections - one managed connection
+    * @exception Throwable Thrown if case of an error
+    */
+   @Test
+   public void testTwoConnections() throws Throwable
+   {
+      assertNotNull(connectionFactory);
+
+      CountDownLatch step1 = new CountDownLatch(1);
+      CountDownLatch step2 = new CountDownLatch(1);
+      CountDownLatch done = new CountDownLatch(2);
+
+      Worker primary = new Worker(connectionFactory, true, step1, step2, done);
+      Thread t1 = new Thread(primary);
+      t1.start();
+
+      Worker secondary = new Worker(connectionFactory, false, step1, step2, done);
+      Thread t2 = new Thread(secondary);
+      t2.start();
+
+      done.await();
+
+      assertNull(primary.getThrowable());
+      assertNull(secondary.getThrowable());
+   }
+
+   /**
+    * Worker
+    */
+   private static class Worker implements Runnable
+   {
+      /** Throwable */
+      private Throwable throwable;
+
+      /** CF */
+      private LazyConnectionFactory connectionFactory;
+
+      /** Primary */
+      private boolean primary;
+
+      /** Step1 */
+      private CountDownLatch step1;
+
+      /** Step2 */
+      private CountDownLatch step2;
+
+      /** Done */
+      private CountDownLatch done;
+
+      /**
+       * Constructor
+       * @param connectionFactory The CF
+       * @param primary Primary worker
+       * @param step1 Step 1 trigger
+       * @param step2 Step 2 trigger
+       * @param done Done trigger
+       */
+      public Worker(LazyConnectionFactory connectionFactory, boolean primary,
+                    CountDownLatch step1, CountDownLatch step2, CountDownLatch done)
+      {
+         this.throwable = null;
+         this.connectionFactory = connectionFactory;
+         this.primary = primary;
+         this.step1 = step1;
+         this.step2 = step2;
+         this.done = done;
+      }
+
+      /**
+       * Get throwable
+       * @return The value
+       */
+      public Throwable getThrowable()
+      {
+         return throwable;
+      }
+
+      /**
+       * {@inheritDoc}
+       */
+      public void run()
+      {
+         LazyConnection lc = null;
+         try
+         {
+            if (!primary)
+            {
+               step1.await();
+               log.info("Step2");
+            }
+            else
+            {
+               log.info("Step1");
+            }
+
+            lc = connectionFactory.getConnection();
+            
+            assertTrue(lc.isManagedConnectionSet());
+
+            if (primary)
+            {
+               step1.countDown();
+               step2.await();
+               log.info("Step3");
+            }
+            else
+            {
+               assertTrue(lc.closeManagedConnection());
+               step2.countDown();
+            }
+
+            assertFalse(lc.isManagedConnectionSet());
+
+            if (primary)
+            {
+               assertTrue(lc.associate());
+               assertTrue(lc.isManagedConnectionSet());
+            }
+         }
+         catch (Throwable t)
+         {
+            t.printStackTrace();
+            throwable = t;
+         }
+         finally
+         {
+            if (lc != null)
+               lc.close();
+
+            done.countDown();
+         }
+      }
+   }
+}

--- a/testsuite/src/test/java/org/ironjacamar/core/connectionmanager/lazy/LazyNoTransactionTestCase.java
+++ b/testsuite/src/test/java/org/ironjacamar/core/connectionmanager/lazy/LazyNoTransactionTestCase.java
@@ -1,0 +1,172 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.ironjacamar.core.connectionmanager.lazy;
+
+import org.ironjacamar.embedded.Configuration;
+import org.ironjacamar.embedded.Deployment;
+import org.ironjacamar.embedded.junit4.AllChecks;
+import org.ironjacamar.embedded.junit4.IronJacamar;
+import org.ironjacamar.embedded.junit4.PostCondition;
+import org.ironjacamar.embedded.junit4.PreCondition;
+import org.ironjacamar.rars.ResourceAdapterFactory;
+import org.ironjacamar.rars.lazy.LazyConnection;
+import org.ironjacamar.rars.lazy.LazyConnectionFactory;
+
+import javax.annotation.Resource;
+import javax.resource.spi.TransactionSupport.TransactionSupportLevel;
+
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test cases for deploying a lazy association resource adapter archive
+ *
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ */
+@RunWith(IronJacamar.class)
+@Configuration(full = true)
+@PreCondition(condition = AllChecks.class)
+@PostCondition(condition = AllChecks.class)
+public class LazyNoTransactionTestCase
+{
+   private static Logger log = Logger.getLogger(LazyNoTransactionTestCase.class);
+
+   /**
+    * Define the deployment
+    * @return The deployment archive
+    * @throws Exception in case of errors
+    */
+   @Deployment(order = 1)
+   public static ResourceAdapterArchive createDeployment() throws Exception
+   {
+      return ResourceAdapterFactory.createLazyRar();
+   }
+
+   /**
+    * Define the deployment
+    * @return The deployment archive
+    * @throws Exception in case of errors
+    */
+   @Deployment(order = 2)
+   public static Descriptor createDescriptor() throws Exception
+   {
+      return ResourceAdapterFactory.createLazyDeployment(TransactionSupportLevel.NoTransaction);
+   }
+
+   @Resource(mappedName = "java:/eis/LazyConnectionFactory")
+   private LazyConnectionFactory connectionFactory;
+
+   /**
+    * Basic
+    * @exception Throwable Thrown if case of an error
+    */
+   @Test
+   public void testBasic() throws Throwable
+   {
+      assertNotNull(connectionFactory);
+
+      LazyConnection lc = null;
+      try
+      {
+         lc = connectionFactory.getConnection();
+
+         assertTrue(lc.isManagedConnectionSet());
+
+         assertTrue(lc.closeManagedConnection());
+
+         assertFalse(lc.isManagedConnectionSet());
+
+         assertTrue(lc.associate());
+
+         assertTrue(lc.isManagedConnectionSet());
+
+         assertFalse(lc.isEnlisted());
+         assertTrue(lc.enlist());
+         assertFalse(lc.isEnlisted());
+      }
+      catch (Throwable t)
+      {
+         log.error(t.getMessage(), t);
+
+         fail("Throwable:" + t.getMessage());
+      }
+      finally
+      {
+         if (lc != null)
+            lc.close();
+      }
+   }
+
+   /**
+    * Two connections - one managed connection
+    * @exception Throwable Thrown if case of an error
+    */
+   @Test
+   public void testTwoConnections() throws Throwable
+   {
+      assertNotNull(connectionFactory);
+
+      LazyConnection lc1 = null;
+      LazyConnection lc2 = null;
+      try
+      {
+         lc1 = connectionFactory.getConnection();
+
+         assertTrue(lc1.isManagedConnectionSet());
+
+         lc2 = connectionFactory.getConnection();
+
+         assertTrue(lc2.isManagedConnectionSet());
+         assertFalse(lc1.isManagedConnectionSet());
+
+         assertTrue(lc2.closeManagedConnection());
+
+         assertFalse(lc1.isManagedConnectionSet());
+         assertFalse(lc2.isManagedConnectionSet());
+
+         assertTrue(lc1.associate());
+
+         assertTrue(lc1.isManagedConnectionSet());
+         assertFalse(lc2.isManagedConnectionSet());
+      }
+      catch (Throwable t)
+      {
+         log.error(t.getMessage(), t);
+
+         fail("Throwable:" + t.getMessage());
+      }
+      finally
+      {
+         if (lc1 != null)
+            lc1.close();
+
+         if (lc2 != null)
+            lc2.close();
+      }
+   }
+}

--- a/testsuite/src/test/java/org/ironjacamar/core/connectionmanager/lazy/LazyXATransactionMTTestCase.java
+++ b/testsuite/src/test/java/org/ironjacamar/core/connectionmanager/lazy/LazyXATransactionMTTestCase.java
@@ -1,0 +1,320 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.ironjacamar.core.connectionmanager.lazy;
+
+import org.ironjacamar.embedded.Configuration;
+import org.ironjacamar.embedded.Deployment;
+import org.ironjacamar.embedded.junit4.AllChecks;
+import org.ironjacamar.embedded.junit4.IronJacamar;
+import org.ironjacamar.embedded.junit4.PostCondition;
+import org.ironjacamar.embedded.junit4.PreCondition;
+import org.ironjacamar.rars.ResourceAdapterFactory;
+import org.ironjacamar.rars.lazy.LazyConnection;
+import org.ironjacamar.rars.lazy.LazyConnectionFactory;
+
+import java.util.concurrent.CountDownLatch;
+
+import javax.annotation.Resource;
+import javax.resource.spi.TransactionSupport.TransactionSupportLevel;
+import javax.transaction.UserTransaction;
+
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test cases for deploying a lazy association resource adapter archive
+ * using multiple threads (XATransaction)
+ *
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ */
+@RunWith(IronJacamar.class)
+@Configuration(full = true)
+@PreCondition(condition = AllChecks.class)
+@PostCondition(condition = AllChecks.class)
+public class LazyXATransactionMTTestCase
+{
+   /** The logger */
+   private static Logger log = Logger.getLogger(LazyXATransactionMTTestCase.class);
+
+   /**
+    * Define the deployment
+    * @return The deployment archive
+    * @throws Exception in case of errors
+    */
+   @Deployment(order = 1)
+   public static ResourceAdapterArchive createDeployment() throws Exception
+   {
+      return ResourceAdapterFactory.createLazyRar();
+   }
+
+   /**
+    * Define the deployment
+    * @return The deployment archive
+    * @throws Exception in case of errors
+    */
+   @Deployment(order = 2)
+   public static Descriptor createDescriptor() throws Exception
+   {
+      return ResourceAdapterFactory.createLazyDeployment(TransactionSupportLevel.XATransaction);
+   }
+
+   @Resource(mappedName = "java:/eis/LazyConnectionFactory")
+   private LazyConnectionFactory connectionFactory;
+
+   @Resource(mappedName = "java:/UserTransaction")
+   private UserTransaction userTransaction;
+
+   /**
+    * Two connections - one managed connection - without enlistment
+    * @exception Throwable Thrown if case of an error
+    */
+   @Test
+   public void testTwoConnectionsWithoutEnlistment() throws Throwable
+   {
+      assertNotNull(connectionFactory);
+      assertNotNull(userTransaction);
+
+      CountDownLatch step1 = new CountDownLatch(1);
+      CountDownLatch step2 = new CountDownLatch(1);
+      CountDownLatch step3 = new CountDownLatch(1);
+      CountDownLatch step4 = new CountDownLatch(1);
+      CountDownLatch done = new CountDownLatch(2);
+
+      Worker primary = new Worker(connectionFactory, userTransaction, false, true, step1, step2, step3, step4, done);
+      Thread t1 = new Thread(primary);
+      t1.start();
+
+      Worker secondary = new Worker(connectionFactory, userTransaction, false, false, step1, step2, step3, step4, done);
+      Thread t2 = new Thread(secondary);
+      t2.start();
+
+      done.await();
+
+      assertNull(primary.getThrowable());
+      assertNull(secondary.getThrowable());
+   }
+
+   /**
+    * Two connections - one managed connection - with enlistment
+    * @exception Throwable Thrown if case of an error
+    */
+   @Test
+   public void testTwoConnectionsWithEnlistment() throws Throwable
+   {
+      assertNotNull(connectionFactory);
+      assertNotNull(userTransaction);
+
+      CountDownLatch step1 = new CountDownLatch(1);
+      CountDownLatch step2 = new CountDownLatch(1);
+      CountDownLatch step3 = new CountDownLatch(1);
+      CountDownLatch step4 = new CountDownLatch(1);
+      CountDownLatch done = new CountDownLatch(2);
+
+      Worker primary = new Worker(connectionFactory, userTransaction, true, true, step1, step2, step3, step4, done);
+      Thread t1 = new Thread(primary);
+      t1.start();
+
+      Worker secondary = new Worker(connectionFactory, userTransaction, true, false, step1, step2, step3, step4, done);
+      Thread t2 = new Thread(secondary);
+      t2.start();
+
+      done.await();
+
+      assertNull(primary.getThrowable());
+      assertNull(secondary.getThrowable());
+   }
+
+   /**
+    * Worker
+    */
+   private static class Worker implements Runnable
+   {
+      /** Throwable */
+      private Throwable throwable;
+
+      /** CF */
+      private LazyConnectionFactory connectionFactory;
+
+      /** UT */
+      private UserTransaction userTransaction;
+
+      /** Enlist */
+      private boolean enlist;
+
+      /** Primary */
+      private boolean primary;
+
+      /** Step1 */
+      private CountDownLatch step1;
+
+      /** Step2 */
+      private CountDownLatch step2;
+
+      /** Step3 */
+      private CountDownLatch step3;
+
+      /** Step4 */
+      private CountDownLatch step4;
+
+      /** Done */
+      private CountDownLatch done;
+
+      /**
+       * Constructor
+       * @param connectionFactory The CF
+       * @param userTransaction The UT
+       * @param enlist Enlistment
+       * @param primary Primary worker
+       * @param step1 Step 1 trigger
+       * @param step2 Step 2 trigger
+       * @param step3 Step 3 trigger
+       * @param step4 Step 4 trigger
+       * @param done Done trigger
+       */
+      public Worker(LazyConnectionFactory connectionFactory, UserTransaction userTransaction,
+                    boolean enlist, boolean primary,
+                    CountDownLatch step1, CountDownLatch step2, CountDownLatch step3, CountDownLatch step4,
+                    CountDownLatch done)
+      {
+         this.throwable = null;
+         this.connectionFactory = connectionFactory;
+         this.userTransaction = userTransaction;
+         this.enlist = enlist;
+         this.primary = primary;
+         this.step1 = step1;
+         this.step2 = step2;
+         this.step3 = step3;
+         this.step4 = step4;
+         this.done = done;
+      }
+
+      /**
+       * Get throwable
+       * @return The value
+       */
+      public Throwable getThrowable()
+      {
+         return throwable;
+      }
+
+      /**
+       * {@inheritDoc}
+       */
+      public void run()
+      {
+         LazyConnection lc = null;
+         boolean status = true;
+         try
+         {
+            userTransaction.begin();
+
+            if (!primary)
+            {
+               step1.await();
+               log.info("Step2");
+            }
+            else
+            {
+               log.info("Step1");
+            }
+
+            if (primary)
+            {
+               lc = connectionFactory.getConnection();
+               assertTrue(lc.isManagedConnectionSet());
+
+               step1.countDown();
+               step2.await();
+               log.info("Step3");
+            }
+            else
+            {
+               try
+               {
+                  lc = connectionFactory.getConnection();
+                  fail("Got a connection");
+               }
+               catch (Exception e)
+               {
+                  step2.countDown();
+               }
+            }
+
+            if (primary)
+            {
+               if (enlist)
+               {
+                  assertFalse(lc.isEnlisted());
+                  assertTrue(lc.enlist());
+                  assertTrue(lc.isEnlisted());
+               }
+
+               step3.countDown();
+               step4.await();
+            }
+            else
+            {
+               step3.await();
+               log.info("Step4");
+               assertNull(lc);
+               step4.countDown();
+            }
+         }
+         catch (Exception e)
+         {
+            log.error(e.getMessage(), e);
+            throwable = e;
+            status = false;
+         }
+         finally
+         {
+            if (lc != null)
+               lc.close();
+
+            try
+            {
+               if (status)
+               {
+                  userTransaction.commit();
+               }
+               else
+               {
+                  userTransaction.rollback();
+               }
+            }
+            catch (Exception e)
+            {
+               log.error(e.getMessage(), e);
+               throwable = e;
+            }
+
+            done.countDown();
+         }
+      }
+   }
+}

--- a/testsuite/src/test/java/org/ironjacamar/core/connectionmanager/lazy/LazyXATransactionTestCase.java
+++ b/testsuite/src/test/java/org/ironjacamar/core/connectionmanager/lazy/LazyXATransactionTestCase.java
@@ -1,0 +1,266 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.ironjacamar.core.connectionmanager.lazy;
+
+import org.ironjacamar.embedded.Configuration;
+import org.ironjacamar.embedded.Deployment;
+import org.ironjacamar.embedded.junit4.AllChecks;
+import org.ironjacamar.embedded.junit4.IronJacamar;
+import org.ironjacamar.embedded.junit4.PostCondition;
+import org.ironjacamar.embedded.junit4.PreCondition;
+import org.ironjacamar.rars.ResourceAdapterFactory;
+import org.ironjacamar.rars.lazy.LazyConnection;
+import org.ironjacamar.rars.lazy.LazyConnectionFactory;
+
+import javax.annotation.Resource;
+import javax.resource.spi.TransactionSupport.TransactionSupportLevel;
+import javax.transaction.UserTransaction;
+
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test cases for deploying a lazy association resource adapter archive using XATransaction
+ *
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ */
+@RunWith(IronJacamar.class)
+@Configuration(full = true)
+@PreCondition(condition = AllChecks.class)
+@PostCondition(condition = AllChecks.class)
+public class LazyXATransactionTestCase
+{
+   private static Logger log = Logger.getLogger(LazyXATransactionTestCase.class);
+
+   /**
+    * Define the deployment
+    * @return The deployment archive
+    * @throws Exception in case of errors
+    */
+   @Deployment(order = 1)
+   public static ResourceAdapterArchive createDeployment() throws Exception
+   {
+      return ResourceAdapterFactory.createLazyRar();
+   }
+
+   /**
+    * Define the deployment
+    * @return The deployment archive
+    * @throws Exception in case of errors
+    */
+   @Deployment(order = 2)
+   public static Descriptor createDescriptor() throws Exception
+   {
+      return ResourceAdapterFactory.createLazyDeployment(TransactionSupportLevel.XATransaction);
+   }
+
+   @Resource(mappedName = "java:/eis/LazyConnectionFactory")
+   private LazyConnectionFactory connectionFactory;
+
+   @Resource(mappedName = "java:/UserTransaction")
+   private UserTransaction userTransaction;
+
+   /**
+    * Basic
+    * @exception Throwable Thrown if case of an error
+    */
+   @Test
+   public void testBasic() throws Throwable
+   {
+      assertNotNull(connectionFactory);
+      assertNotNull(userTransaction);
+
+      boolean status = true;
+      userTransaction.begin();
+
+      LazyConnection lc = null;
+      try
+      {
+         lc = connectionFactory.getConnection();
+
+         assertTrue(lc.isManagedConnectionSet());
+
+         lc.closeManagedConnection();
+
+         assertFalse(lc.isManagedConnectionSet());
+
+         lc.associate();
+
+         assertTrue(lc.isManagedConnectionSet());
+
+         assertFalse(lc.isEnlisted());
+         assertTrue(lc.enlist());
+         assertTrue(lc.isEnlisted());
+      }
+      catch (Throwable t)
+      {
+         log.error(t.getMessage(), t);
+         status = false;
+         fail("Throwable:" + t.getMessage());
+      }
+      finally
+      {
+         if (lc != null)
+            lc.close();
+
+         if (status)
+         {
+            userTransaction.commit();
+         }
+         else
+         {
+            userTransaction.rollback();
+         }
+      }
+   }
+
+   /**
+    * Two connections - one managed connection - without enlistment
+    * @exception Throwable Thrown if case of an error
+    */
+   @Test
+   public void testTwoConnectionsWithoutEnlistment() throws Throwable
+   {
+      assertNotNull(connectionFactory);
+      assertNotNull(userTransaction);
+
+      boolean status = true;
+      userTransaction.begin();
+
+      LazyConnection lc1 = null;
+      LazyConnection lc2 = null;
+      try
+      {
+         lc1 = connectionFactory.getConnection();
+
+         assertTrue(lc1.isManagedConnectionSet());
+
+         lc2 = connectionFactory.getConnection();
+
+         assertTrue(lc2.isManagedConnectionSet());
+         assertFalse(lc1.isManagedConnectionSet());
+
+         assertTrue(lc2.closeManagedConnection());
+
+         assertFalse(lc1.isManagedConnectionSet());
+         assertFalse(lc2.isManagedConnectionSet());
+
+         assertTrue(lc1.associate());
+
+         assertTrue(lc1.isManagedConnectionSet());
+         assertFalse(lc2.isManagedConnectionSet());
+      }
+      catch (Throwable t)
+      {
+         log.error(t.getMessage(), t);
+         status = false;
+         fail("Throwable:" + t.getMessage());
+      }
+      finally
+      {
+         if (lc1 != null)
+            lc1.close();
+
+         if (lc2 != null)
+            lc2.close();
+
+         if (status)
+         {
+            userTransaction.commit();
+         }
+         else
+         {
+            userTransaction.rollback();
+         }
+      }
+   }
+
+   /**
+    * Two connections - one managed connection - with enlistment
+    * @exception Throwable Thrown if case of an error
+    */
+   @Test
+   public void testTwoConnectionsWithEnlistment() throws Throwable
+   {
+      assertNotNull(connectionFactory);
+      assertNotNull(userTransaction);
+
+      boolean status = true;
+      userTransaction.begin();
+
+      LazyConnection lc1 = null;
+      LazyConnection lc2 = null;
+      try
+      {
+         lc1 = connectionFactory.getConnection();
+
+         assertTrue(lc1.isManagedConnectionSet());
+         assertFalse(lc1.isEnlisted());
+         assertTrue(lc1.enlist());
+         assertTrue(lc1.isEnlisted());
+
+         lc2 = connectionFactory.getConnection();
+
+         assertTrue(lc2.isManagedConnectionSet());
+         assertFalse(lc1.isManagedConnectionSet());
+
+         assertTrue(lc2.closeManagedConnection());
+
+         assertFalse(lc1.isManagedConnectionSet());
+         assertFalse(lc2.isManagedConnectionSet());
+
+         assertTrue(lc1.associate());
+
+         assertTrue(lc1.isManagedConnectionSet());
+         assertFalse(lc2.isManagedConnectionSet());
+      }
+      catch (Throwable t)
+      {
+         log.error(t.getMessage(), t);
+         status = false;
+         fail("Throwable:" + t.getMessage());
+      }
+      finally
+      {
+         if (lc1 != null)
+            lc1.close();
+
+         if (lc2 != null)
+            lc2.close();
+
+         if (status)
+         {
+            userTransaction.commit();
+         }
+         else
+         {
+            userTransaction.rollback();
+         }
+      }
+   }
+}

--- a/testsuite/src/test/java/org/ironjacamar/core/connectionmanager/lazy/package-info.java
+++ b/testsuite/src/test/java/org/ironjacamar/core/connectionmanager/lazy/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+/**
+ * Test cases for the LazyConnectionManager
+ */
+package org.ironjacamar.core.connectionmanager.lazy;

--- a/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyConnection.java
+++ b/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyConnection.java
@@ -1,0 +1,63 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.ironjacamar.rars.lazy;
+
+/**
+ * LazyConnection
+ */
+public interface LazyConnection
+{
+   /**
+    * isManagedConnectionSet
+    * @return boolean
+    */
+   public boolean isManagedConnectionSet();
+
+   /**
+    * Close managed connection
+    * @return boolean
+    */
+   public boolean closeManagedConnection();
+
+   /**
+    * Associate
+    * @return boolean
+    */
+   public boolean associate();
+
+   /**
+    * Is enlisted
+    * @return The value
+    */
+   public boolean isEnlisted();
+
+   /**
+    * Enlist
+    * @return boolean
+    */
+   public boolean enlist();
+
+   /**
+    * Close
+    */
+   public void close();
+}

--- a/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyConnectionFactory.java
+++ b/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyConnectionFactory.java
@@ -1,0 +1,44 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.ironjacamar.rars.lazy;
+
+import java.io.Serializable;
+
+import javax.resource.Referenceable;
+import javax.resource.ResourceException;
+
+/**
+ * LazyConnectionFactory
+ *
+ * @version $Revision: $
+ */
+public interface LazyConnectionFactory extends Serializable, Referenceable
+{
+   /** 
+    * Get connection from factory
+    *
+    * @return LazyConnection instance
+    * @exception ResourceException Thrown if a connection can't be obtained
+    */
+   public LazyConnection getConnection() throws ResourceException;
+
+}

--- a/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyConnectionFactoryImpl.java
+++ b/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyConnectionFactoryImpl.java
@@ -1,0 +1,109 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.ironjacamar.rars.lazy;
+
+import javax.naming.NamingException;
+import javax.naming.Reference;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.ConnectionManager;
+
+import org.jboss.logging.Logger;
+
+/**
+ * LazyConnectionFactoryImpl
+ *
+ * @version $Revision: $
+ */
+public class LazyConnectionFactoryImpl implements LazyConnectionFactory
+{
+   /** The serial version UID */
+   private static final long serialVersionUID = 1L;
+
+   /** The logger */
+   private static Logger log = Logger.getLogger(LazyConnectionFactoryImpl.class);
+
+   /** Reference */
+   private Reference reference;
+
+   /** ManagedConnectionFactory */
+   private LazyManagedConnectionFactory mcf;
+
+   /** ConnectionManager */
+   private ConnectionManager connectionManager;
+
+   /**
+    * Default constructor
+    */
+   public LazyConnectionFactoryImpl()
+   {
+   }
+
+   /**
+    * Default constructor
+    * @param mcf ManagedConnectionFactory
+    * @param cxManager ConnectionManager
+    */
+   public LazyConnectionFactoryImpl(LazyManagedConnectionFactory mcf, ConnectionManager cxManager)
+   {
+      this.mcf = mcf;
+      this.connectionManager = cxManager;
+   }
+
+   /** 
+    * Get connection from factory
+    *
+    * @return LazyConnection instance
+    * @exception ResourceException Thrown if a connection can't be obtained
+    */
+   @Override
+   public LazyConnection getConnection() throws ResourceException
+   {
+      log.trace("getConnection()");
+      return (LazyConnection)connectionManager.allocateConnection(mcf, null);
+   }
+
+   /**
+    * Get the Reference instance.
+    *
+    * @return Reference instance
+    * @exception NamingException Thrown if a reference can't be obtained
+    */
+   @Override
+   public Reference getReference() throws NamingException
+   {
+      log.trace("getReference()");
+      return reference;
+   }
+
+   /**
+    * Set the Reference instance.
+    *
+    * @param reference A Reference instance
+    */
+   @Override
+   public void setReference(Reference reference)
+   {
+      log.trace("setReference()");
+      this.reference = reference;
+   }
+}

--- a/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyConnectionImpl.java
+++ b/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyConnectionImpl.java
@@ -1,0 +1,198 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.ironjacamar.rars.lazy;
+
+import javax.resource.spi.ConnectionManager;
+import javax.resource.spi.ConnectionRequestInfo;
+import javax.resource.spi.LazyAssociatableConnectionManager;
+
+import org.jboss.logging.Logger;
+
+/**
+ * LazyConnectionImpl
+ *
+ * @version $Revision: $
+ */
+public class LazyConnectionImpl implements LazyConnection
+{
+   /** The logger */
+   private static Logger log = Logger.getLogger(LazyConnectionImpl.class);
+
+   /** Connection manager */
+   private ConnectionManager cm;
+
+   /** ManagedConnection */
+   private LazyManagedConnection mc;
+
+   /** ManagedConnectionFactory */
+   private LazyManagedConnectionFactory mcf;
+
+   /** ConnectionRequestInfo */
+   private ConnectionRequestInfo cri;
+
+   /**
+    * Default constructor
+    * @param mc LazyManagedConnection
+    * @param mcf LazyManagedConnectionFactory
+    * @param cm ConnectionManager
+    * @param cri ConnectionRequestInfo
+    */
+   public LazyConnectionImpl(LazyManagedConnection mc, LazyManagedConnectionFactory mcf,
+                             ConnectionManager cm, ConnectionRequestInfo cri)
+   {
+      this.mc = mc;
+      this.mcf = mcf;
+      this.cm = cm;
+      this.cri = cri;
+   }
+
+   /**
+    * Call isManagedConnectionSet
+    * @return boolean
+    */
+   public boolean isManagedConnectionSet()
+   {
+      log.tracef("%s: isManagedConnectionSet() => %s", this, mc != null);
+
+      return mc != null;
+   }
+
+   /**
+    * Close managed connection
+    * @return boolean
+    */
+   public boolean closeManagedConnection()
+   {
+      log.tracef("%s: closeManagedConnection()", this);
+
+      if (mc != null)
+      {
+         try
+         {
+            if (cm instanceof org.ironjacamar.core.api.connectionmanager.ConnectionManager)
+            {
+               org.ironjacamar.core.api.connectionmanager.ConnectionManager ijCm =
+                  (org.ironjacamar.core.api.connectionmanager.ConnectionManager)cm;
+
+               boolean result = ijCm.dissociateManagedConnection(this, mc, mcf);
+               log.trace("Result=" + result);
+
+               mc = null;
+               return true;
+            }
+         }
+         catch (Throwable t)
+         {
+            log.error("CloseManagedConnection", t);
+         }
+      }
+
+      return false;
+   }
+
+   /**
+    * Associate
+    * @return boolean
+    */
+   public boolean associate()
+   {
+      log.tracef("%s: associate()", this);
+      if (mc == null)
+      {
+         if (cm instanceof LazyAssociatableConnectionManager)
+         {
+            try
+            {
+               LazyAssociatableConnectionManager lacm = (LazyAssociatableConnectionManager)cm;
+               lacm.associateConnection(this, mcf, cri);
+               return true;
+            }
+            catch (Throwable t)
+            {
+               log.error("Associate", t);
+            }
+         }
+         else if (cm instanceof org.ironjacamar.core.api.connectionmanager.ConnectionManager)
+         {
+            try
+            {
+               org.ironjacamar.core.api.connectionmanager.ConnectionManager ijCm =
+                  (org.ironjacamar.core.api.connectionmanager.ConnectionManager)cm;
+               mc = (LazyManagedConnection)ijCm.associateManagedConnection(this, mcf, cri);
+               return mc != null;
+            }
+            catch (Throwable t)
+            {
+               log.error("Associate", t);
+            }
+         }
+      }
+
+      return false;
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   public boolean isEnlisted()
+   {
+      return mc.isEnlisted();
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   public boolean enlist()
+   {
+      return mc.enlist();
+   }
+
+   /**
+    * Close
+    */
+   public void close()
+   {
+      log.tracef("%s: close()", this);
+      if (mc != null)
+      {
+         mc.closeHandle(this);
+      }
+      else
+      {
+         if (cm instanceof LazyAssociatableConnectionManager)
+         {
+            LazyAssociatableConnectionManager lacm = (LazyAssociatableConnectionManager)cm;
+            lacm.inactiveConnectionClosed(this, mcf);
+         }
+      }
+   }
+
+   /**
+    * Set the managed connection
+    * @param mc The value
+    */
+   void setManagedConnection(LazyManagedConnection mc)
+   {
+      log.tracef("%s: setManagedConnection(" + mc + ")", this);
+      this.mc = mc;
+   }
+}

--- a/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyLocalTransaction.java
+++ b/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyLocalTransaction.java
@@ -1,0 +1,75 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.ironjacamar.rars.lazy;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.LocalTransaction;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Lazy local transaction
+ */
+public class LazyLocalTransaction implements LocalTransaction
+{
+   /** The logger */
+   private static Logger log = Logger.getLogger(LazyLocalTransaction.class);
+
+   /** The managed connection */
+   private LazyManagedConnection mc;
+
+   /**
+    * Constructor
+    * @param mc The managed connection
+    */
+   public LazyLocalTransaction(LazyManagedConnection mc)
+   {
+      this.mc = mc;
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   public void begin() throws ResourceException
+   {
+      log.trace("begin");
+      mc.setEnlisted(true);
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   public void commit() throws ResourceException
+   {
+      log.trace("commit");
+      mc.setEnlisted(false);
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   public void rollback() throws ResourceException
+   {
+      log.trace("rollback");
+      mc.setEnlisted(false);
+   }
+}

--- a/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyManagedConnection.java
+++ b/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyManagedConnection.java
@@ -1,0 +1,360 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.ironjacamar.rars.lazy;
+
+import java.io.PrintWriter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.resource.NotSupportedException;
+import javax.resource.ResourceException;
+import javax.resource.spi.ConnectionEvent;
+import javax.resource.spi.ConnectionEventListener;
+import javax.resource.spi.ConnectionManager;
+import javax.resource.spi.ConnectionRequestInfo;
+import javax.resource.spi.DissociatableManagedConnection;
+import javax.resource.spi.LazyEnlistableConnectionManager;
+import javax.resource.spi.LazyEnlistableManagedConnection;
+import javax.resource.spi.LocalTransaction;
+import javax.resource.spi.ManagedConnection;
+import javax.resource.spi.ManagedConnectionMetaData;
+
+import javax.security.auth.Subject;
+import javax.transaction.xa.XAResource;
+
+import org.jboss.logging.Logger;
+
+/**
+ * LazyManagedConnection
+ */
+public class LazyManagedConnection implements ManagedConnection, DissociatableManagedConnection,
+                                              LazyEnlistableManagedConnection
+{
+   /** The logger */
+   private static Logger log = Logger.getLogger(LazyManagedConnection.class);
+
+   /** The logwriter */
+   private PrintWriter logwriter;
+
+   /** Connection manager */
+   private ConnectionManager cm;
+
+   /** ManagedConnectionFactory */
+   private LazyManagedConnectionFactory mcf;
+
+   /** Listeners */
+   private List<ConnectionEventListener> listeners;
+
+   /** Connection */
+   private LazyConnectionImpl connection;
+
+   /** Local transaction support */
+   private boolean localTransaction;
+
+   /** XA transaction support */
+   private boolean xaTransaction;
+
+   /** Enlisted */
+   private boolean enlisted;
+
+   /** Lazy local transaction */
+   private LazyLocalTransaction lazyLocalTransaction;
+
+   /** Lazy XAResource */
+   private LazyXAResource lazyXAResource;
+
+   /**
+    * Default constructor
+    * @param localTransaction Support local transaction
+    * @param xaTransaction Support XA transaction
+    * @param mcf The managed connection factory
+    * @param cm The connection manager
+    */
+   public LazyManagedConnection(boolean localTransaction, boolean xaTransaction,
+                                LazyManagedConnectionFactory mcf, ConnectionManager cm)
+   {
+      this.localTransaction = localTransaction;
+      this.xaTransaction = xaTransaction;
+      this.enlisted = false;
+      this.mcf = mcf;
+      this.cm = cm;
+      this.logwriter = null;
+      this.listeners = Collections.synchronizedList(new ArrayList<ConnectionEventListener>(1));
+      this.connection = null;
+      this.lazyLocalTransaction = null;
+      this.lazyXAResource = null;
+
+      if (localTransaction)
+         this.lazyLocalTransaction = new LazyLocalTransaction(this);
+
+      if (xaTransaction)
+         this.lazyXAResource = new LazyXAResource(this);
+   }
+
+   /**
+    * Creates a new connection handle for the underlying physical connection 
+    * represented by the ManagedConnection instance. 
+    *
+    * @param subject Security context as JAAS subject
+    * @param cxRequestInfo ConnectionRequestInfo instance
+    * @return generic Object instance representing the connection handle. 
+    * @throws ResourceException generic exception if operation fails
+    */
+   public Object getConnection(Subject subject, ConnectionRequestInfo cxRequestInfo) throws ResourceException
+   {
+      log.trace("getConnection()");
+
+      if (connection != null)
+      {
+         connection.setManagedConnection(null);
+      }
+         
+      connection = new LazyConnectionImpl(this, mcf, cm, cxRequestInfo);
+      return connection;
+   }
+
+   /**
+    * Used by the container to change the association of an 
+    * application-level connection handle with a ManagedConneciton instance.
+    *
+    * @param connection Application-level connection handle
+    * @throws ResourceException generic exception if operation fails
+    */
+   public void associateConnection(Object connection) throws ResourceException
+   {
+      log.trace("associateConnection()");
+
+      if (this.connection != null)
+      {
+         this.connection.setManagedConnection(null);
+      }
+
+      if (connection != null)
+      {
+         if (!(connection instanceof LazyConnectionImpl))
+            throw new ResourceException("Connection isn't LazyConnectionImpl: " + connection.getClass().getName());
+
+         this.connection = (LazyConnectionImpl)connection;
+         this.connection.setManagedConnection(this);
+      }
+      else
+      {
+         this.connection = null;
+      }
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   public void dissociateConnections() throws ResourceException
+   {
+      log.trace("dissociateConnections()");
+
+      if (connection != null)
+      {
+         connection.setManagedConnection(null);
+         connection = null;
+      }
+   }
+
+   /**
+    * Application server calls this method to force any cleanup on the ManagedConnection instance.
+    *
+    * @throws ResourceException generic exception if operation fails
+    */
+   public void cleanup() throws ResourceException
+   {
+      log.trace("cleanup()");
+
+      if (connection != null)
+      {
+         connection.setManagedConnection(null);
+         connection = null;
+      }
+   }
+
+   /**
+    * Destroys the physical connection to the underlying resource manager.
+    *
+    * @throws ResourceException generic exception if operation fails
+    */
+   public void destroy() throws ResourceException
+   {
+      log.trace("destroy()");
+   }
+
+   /**
+    * Adds a connection event listener to the ManagedConnection instance.
+    *
+    * @param listener A new ConnectionEventListener to be registered
+    */
+   public void addConnectionEventListener(ConnectionEventListener listener)
+   {
+      log.trace("addConnectionEventListener()");
+      if (listener == null)
+         throw new IllegalArgumentException("Listener is null");
+      listeners.add(listener);
+   }
+
+   /**
+    * Removes an already registered connection event listener from the ManagedConnection instance.
+    *
+    * @param listener already registered connection event listener to be removed
+    */
+   public void removeConnectionEventListener(ConnectionEventListener listener)
+   {
+      log.trace("removeConnectionEventListener()");
+      if (listener == null)
+         throw new IllegalArgumentException("Listener is null");
+      listeners.remove(listener);
+   }
+
+   /**
+    * Is enlisted
+    * @return The value
+    */
+   boolean isEnlisted()
+   {
+      return enlisted;
+   }
+
+   /**
+    * Set enlisted
+    * @param v The value
+    */
+   void setEnlisted(boolean v)
+   {
+      enlisted = v;
+   }
+
+   /**
+    * Enlist
+    * @return boolean
+    */
+   boolean enlist()
+   {
+      try
+      {
+         if (cm instanceof LazyEnlistableConnectionManager)
+         {
+            LazyEnlistableConnectionManager lecm = (LazyEnlistableConnectionManager)cm;
+            lecm.lazyEnlist(this);
+            return true;
+         }
+      }
+      catch (Throwable t)
+      {
+         log.error(t.getMessage(), t);
+      }
+
+      return false;
+   }
+
+   /**
+    * Close handle
+    *
+    * @param handle The handle
+    */
+   void closeHandle(LazyConnection handle)
+   {
+      ConnectionEvent event = new ConnectionEvent(this, ConnectionEvent.CONNECTION_CLOSED);
+      event.setConnectionHandle(handle);
+      for (ConnectionEventListener cel : listeners)
+      {
+         cel.connectionClosed(event);
+      }
+   }
+
+   /**
+    * Gets the log writer for this ManagedConnection instance.
+    *
+    * @return Character ourput stream associated with this Managed-Connection instance
+    * @throws ResourceException generic exception if operation fails
+    */
+   public PrintWriter getLogWriter() throws ResourceException
+   {
+      log.trace("getLogWriter()");
+      return logwriter;
+   }
+
+   /**
+    * Sets the log writer for this ManagedConnection instance.
+    *
+    * @param out Character Output stream to be associated
+    * @throws ResourceException  generic exception if operation fails
+    */
+   public void setLogWriter(PrintWriter out) throws ResourceException
+   {
+      log.trace("setLogWriter()");
+      logwriter = out;
+   }
+
+   /**
+    * Returns an <code>javax.resource.spi.LocalTransaction</code> instance.
+    *
+    * @return LocalTransaction instance
+    * @throws ResourceException generic exception if operation fails
+    */
+   public LocalTransaction getLocalTransaction() throws ResourceException
+   {
+      if (!localTransaction || xaTransaction)
+      {
+         throw new NotSupportedException("LocalTransaction not supported");
+      }
+      else
+      {
+         return lazyLocalTransaction;
+      }
+   }
+
+   /**
+    * Returns an <code>javax.transaction.xa.XAresource</code> instance. 
+    *
+    * @return XAResource instance
+    * @throws ResourceException generic exception if operation fails
+    */
+   public XAResource getXAResource() throws ResourceException
+   {
+      if (!xaTransaction || localTransaction)
+      {
+         throw new NotSupportedException("GetXAResource not supported not supported");
+      }
+      else
+      {
+         return lazyXAResource;
+      }
+   }
+
+   /**
+    * Gets the metadata information for this connection's underlying EIS resource manager instance. 
+    *
+    * @return ManagedConnectionMetaData instance
+    * @throws ResourceException generic exception if operation fails
+    */
+   public ManagedConnectionMetaData getMetaData() throws ResourceException
+   {
+      log.trace("getMetaData()");
+      return new LazyManagedConnectionMetaData();
+   }
+}

--- a/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyManagedConnectionFactory.java
+++ b/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyManagedConnectionFactory.java
@@ -1,0 +1,221 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.ironjacamar.rars.lazy;
+
+import java.io.PrintWriter;
+import java.util.Iterator;
+import java.util.Set;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.ConnectionManager;
+import javax.resource.spi.ConnectionRequestInfo;
+import javax.resource.spi.ManagedConnection;
+import javax.resource.spi.ManagedConnectionFactory;
+import javax.resource.spi.ResourceAdapter;
+import javax.resource.spi.ResourceAdapterAssociation;
+
+import javax.security.auth.Subject;
+
+import org.jboss.logging.Logger;
+
+/**
+ * LazyManagedConnectionFactory
+ *
+ * @version $Revision: $
+ */
+public class LazyManagedConnectionFactory implements ManagedConnectionFactory, ResourceAdapterAssociation
+{
+
+   /** The serial version UID */
+   private static final long serialVersionUID = 1L;
+
+   /** The logger */
+   private static Logger log = Logger.getLogger(LazyManagedConnectionFactory.class);
+
+   /** Connection manager */
+   private ConnectionManager cm;
+
+   /** The resource adapter */
+   private ResourceAdapter ra;
+
+   /** The logwriter */
+   private PrintWriter logwriter;
+
+   /**
+    * Default constructor
+    */
+   public LazyManagedConnectionFactory()
+   {
+      this.cm = null;
+      this.ra = null;
+      this.logwriter = null;
+   }
+
+   /**
+    * Creates a Connection Factory instance. 
+    *
+    * @param cxManager ConnectionManager to be associated with created EIS connection factory instance
+    * @return EIS-specific Connection Factory instance or javax.resource.cci.ConnectionFactory instance
+    * @throws ResourceException Generic exception
+    */
+   public Object createConnectionFactory(ConnectionManager cxManager) throws ResourceException
+   {
+      log.trace("createConnectionFactory()");
+
+      this.cm = cxManager;
+
+      return new LazyConnectionFactoryImpl(this, cxManager);
+   }
+
+   /**
+    * Creates a Connection Factory instance. 
+    *
+    * @return EIS-specific Connection Factory instance or javax.resource.cci.ConnectionFactory instance
+    * @throws ResourceException Generic exception
+    */
+   public Object createConnectionFactory() throws ResourceException
+   {
+      throw new ResourceException("This resource adapter doesn't support non-managed environments");
+   }
+
+   /**
+    * Creates a new physical connection to the underlying EIS resource manager.
+    *
+    * @param subject Caller's security information
+    * @param cxRequestInfo Additional resource adapter specific connection request information
+    * @throws ResourceException generic exception
+    * @return ManagedConnection instance 
+    */
+   public ManagedConnection createManagedConnection(Subject subject,
+         ConnectionRequestInfo cxRequestInfo) throws ResourceException
+   {
+      log.trace("createManagedConnection()");
+
+      LazyResourceAdapter lra = (LazyResourceAdapter)ra;
+
+      return new LazyManagedConnection(lra.getLocalTransaction().booleanValue(),
+                                       lra.getXATransaction().booleanValue(),
+                                       this, cm);
+   }
+
+   /**
+    * Returns a matched connection from the candidate set of connections. 
+    *
+    * @param connectionSet Candidate connection set
+    * @param subject Caller's security information
+    * @param cxRequestInfo Additional resource adapter specific connection request information
+    * @throws ResourceException generic exception
+    * @return ManagedConnection if resource adapter finds an acceptable match otherwise null 
+    */
+   public ManagedConnection matchManagedConnections(Set connectionSet,
+         Subject subject, ConnectionRequestInfo cxRequestInfo) throws ResourceException
+   {
+      log.trace("matchManagedConnections()");
+      ManagedConnection result = null;
+      Iterator it = connectionSet.iterator();
+      while (result == null && it.hasNext())
+      {
+         ManagedConnection mc = (ManagedConnection)it.next();
+         if (mc instanceof LazyManagedConnection)
+         {
+            result = mc;
+         }
+      }
+      return result;
+   }
+
+   /**
+    * Get the log writer for this ManagedConnectionFactory instance.
+    *
+    * @return PrintWriter
+    * @throws ResourceException generic exception
+    */
+   public PrintWriter getLogWriter() throws ResourceException
+   {
+      log.trace("getLogWriter()");
+      return logwriter;
+   }
+
+   /**
+    * Set the log writer for this ManagedConnectionFactory instance.
+    *
+    * @param out PrintWriter - an out stream for error logging and tracing
+    * @throws ResourceException generic exception
+    */
+   public void setLogWriter(PrintWriter out) throws ResourceException
+   {
+      log.trace("setLogWriter()");
+      logwriter = out;
+   }
+
+   /**
+    * Get the resource adapter
+    *
+    * @return The handle
+    */
+   public ResourceAdapter getResourceAdapter()
+   {
+      log.trace("getResourceAdapter()");
+      return ra;
+   }
+
+   /**
+    * Set the resource adapter
+    *
+    * @param ra The handle
+    */
+   public void setResourceAdapter(ResourceAdapter ra)
+   {
+      log.trace("setResourceAdapter()");
+      this.ra = ra;
+   }
+
+   /** 
+    * Returns a hash code value for the object.
+    * @return A hash code value for this object.
+    */
+   @Override
+   public int hashCode()
+   {
+      int result = 17;
+      return result;
+   }
+
+   /** 
+    * Indicates whether some other object is equal to this one.
+    * @param other The reference object with which to compare.
+    * @return true if this object is the same as the obj argument, false otherwise.
+    */
+   @Override
+   public boolean equals(Object other)
+   {
+      if (other == null)
+         return false;
+      if (other == this)
+         return true;
+      if (!(other instanceof LazyManagedConnectionFactory))
+         return false;
+      LazyManagedConnectionFactory obj = (LazyManagedConnectionFactory)other;
+      boolean result = true; 
+      return result;
+   }
+}

--- a/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyManagedConnectionMetaData.java
+++ b/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyManagedConnectionMetaData.java
@@ -1,0 +1,98 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.ironjacamar.rars.lazy;
+
+import javax.resource.ResourceException;
+
+import javax.resource.spi.ManagedConnectionMetaData;
+
+import org.jboss.logging.Logger;
+
+/**
+ * LazyManagedConnectionMetaData
+ *
+ * @version $Revision: $
+ */
+public class LazyManagedConnectionMetaData implements ManagedConnectionMetaData
+{
+   /** The logger */
+   private static Logger log = Logger.getLogger(LazyManagedConnectionMetaData.class);
+
+   /**
+    * Default constructor
+    */
+   public LazyManagedConnectionMetaData()
+   {
+   }
+
+   /**
+    * Returns Product name of the underlying EIS instance connected through the ManagedConnection.
+    *
+    * @return Product name of the EIS instance
+    * @throws ResourceException Thrown if an error occurs
+    */
+   @Override
+   public String getEISProductName() throws ResourceException
+   {
+      log.trace("getEISProductName()");
+      return "Lazy";
+   }
+
+   /**
+    * Returns Product version of the underlying EIS instance connected through the ManagedConnection.
+    *
+    * @return Product version of the EIS instance
+    * @throws ResourceException Thrown if an error occurs
+    */
+   @Override
+   public String getEISProductVersion() throws ResourceException
+   {
+      log.trace("getEISProductVersion()");
+      return "1.0";
+   }
+
+   /**
+    * Returns maximum limit on number of active concurrent connections 
+    *
+    * @return Maximum limit for number of active concurrent connections
+    * @throws ResourceException Thrown if an error occurs
+    */
+   @Override
+   public int getMaxConnections() throws ResourceException
+   {
+      log.trace("getMaxConnections()");
+      return 0;
+   }
+
+   /**
+    * Returns name of the user associated with the ManagedConnection instance
+    *
+    * @return Name of the user
+    * @throws ResourceException Thrown if an error occurs
+    */
+   @Override
+   public String getUserName() throws ResourceException
+   {
+      log.trace("getUserName()");
+      return null;
+   }
+}

--- a/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyRaMetaData.java
+++ b/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyRaMetaData.java
@@ -1,0 +1,141 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.ironjacamar.rars.lazy;
+
+import javax.resource.cci.ResourceAdapterMetaData;
+
+/**
+ * LazyRaMetaData
+ */
+public class LazyRaMetaData implements ResourceAdapterMetaData
+{
+   /** Local transaction */
+   private boolean localTransaction;
+
+   /**
+    * Constructor
+    * @param localTransaction Support LocalTransaction
+    */
+   public LazyRaMetaData(boolean localTransaction)
+   {
+      this.localTransaction = localTransaction;
+   }
+
+   /**
+    * Gets the version of the resource adapter.
+    *
+    * @return String representing version of the resource adapter
+    */
+   @Override
+   public String getAdapterVersion()
+   {
+      return "1.0";
+   }
+
+   /**
+    * Gets the name of the vendor that has provided the resource adapter.
+    *
+    * @return String representing name of the vendor 
+    */
+   @Override
+   public String getAdapterVendorName()
+   {
+      return "JBoss, by Red Hat";
+   }
+
+   /**
+    * Gets a tool displayable name of the resource adapter.
+    *
+    * @return String representing the name of the resource adapter
+    */
+   @Override
+   public String getAdapterName()
+   {
+      return "Lazy resource adapter";
+   }
+
+   /**
+    * Gets a tool displayable short desription of the resource adapter.
+    *
+    * @return String describing the resource adapter
+    */
+   @Override
+   public String getAdapterShortDescription()
+   {
+      return "Lazy connection association";
+   }
+
+   /**
+    * Returns a string representation of the version
+    *
+    * @return String representing the supported version of the connector architecture
+    */
+   @Override
+   public String getSpecVersion()
+   {
+      return "1.5";
+   }
+
+   /**
+    * Returns an array of fully-qualified names of InteractionSpec
+    *
+    * @return Array of fully-qualified class names of InteractionSpec classes
+    */
+   @Override
+   public String[] getInteractionSpecsSupported()
+   {
+      return null;
+   }
+
+   /**
+    * Returns true if the implementation class for the Interaction
+    *
+    * @return boolean Depending on method support
+    */
+   @Override
+   public boolean supportsExecuteWithInputAndOutputRecord()
+   {
+      return false;
+   }
+
+   /**
+    * Returns true if the implementation class for the Interaction
+    *
+    * @return boolean Depending on method support
+    */
+   @Override
+   public boolean supportsExecuteWithInputRecordOnly()
+   {
+      return false;
+   }
+
+   /**
+    * Returns true if the resource adapter implements the LocalTransaction
+    *
+    * @return true If resource adapter supports resource manager local transaction demarcation 
+    */
+   @Override
+   public boolean supportsLocalTransactionDemarcation()
+   {
+      return localTransaction;
+   }
+}

--- a/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyResourceAdapter.java
+++ b/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyResourceAdapter.java
@@ -1,0 +1,238 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.ironjacamar.rars.lazy;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.ActivationSpec;
+import javax.resource.spi.BootstrapContext;
+import javax.resource.spi.ResourceAdapter;
+import javax.resource.spi.ResourceAdapterInternalException;
+import javax.resource.spi.endpoint.MessageEndpointFactory;
+
+import javax.transaction.xa.XAResource;
+
+import org.jboss.logging.Logger;
+
+/**
+ * LazyResourceAdapter
+ */
+public class LazyResourceAdapter implements ResourceAdapter
+{
+   /** The logger */
+   private static Logger log = Logger.getLogger(LazyResourceAdapter.class);
+
+   /** Enable */
+   private Boolean enable;
+
+   /** Local transaction */
+   private Boolean localTransaction;
+
+   /** XA transaction */
+   private Boolean xaTransaction;
+
+   /**
+    * Default constructor
+    */
+   public LazyResourceAdapter()
+   {
+      enable = Boolean.TRUE;
+      localTransaction = Boolean.FALSE;
+      xaTransaction = Boolean.FALSE;
+   }
+
+   /** 
+    * Set Enable
+    * @param value The value
+    */
+   public void setEnable(Boolean value)
+   {
+      this.enable = value;
+   }
+
+   /** 
+    * Get Enable
+    * @return The value
+    */
+   public Boolean getEnable()
+   {
+      return enable;
+   }
+
+   /** 
+    * Set LocalTransaction
+    * @param value The value
+    */
+   public void setLocalTransaction(Boolean value)
+   {
+      this.localTransaction = value;
+   }
+
+   /** 
+    * Get LocalTransaction
+    * @return The value
+    */
+   public Boolean getLocalTransaction()
+   {
+      return localTransaction;
+   }
+
+   /** 
+    * Set XATransaction
+    * @param value The value
+    */
+   public void setXATransaction(Boolean value)
+   {
+      this.xaTransaction = value;
+   }
+
+   /** 
+    * Get XATransaction
+    * @return The value
+    */
+   public Boolean getXATransaction()
+   {
+      return xaTransaction;
+   }
+
+   /**
+    * This is called during the activation of a message endpoint.
+    *
+    * @param endpointFactory A message endpoint factory instance.
+    * @param spec An activation spec JavaBean instance.
+    * @throws ResourceException generic exception 
+    */
+   public void endpointActivation(MessageEndpointFactory endpointFactory,
+      ActivationSpec spec) throws ResourceException
+   {
+      log.trace("endpointActivation()");
+   }
+
+   /**
+    * This is called when a message endpoint is deactivated. 
+    *
+    * @param endpointFactory A message endpoint factory instance.
+    * @param spec An activation spec JavaBean instance.
+    */
+   public void endpointDeactivation(MessageEndpointFactory endpointFactory,
+      ActivationSpec spec)
+   {
+      log.trace("endpointDeactivation()");
+   }
+
+   /**
+    * This is called when a resource adapter instance is bootstrapped.
+    *
+    * @param ctx A bootstrap context containing references 
+    * @throws ResourceAdapterInternalException indicates bootstrap failure.
+    */
+   public void start(BootstrapContext ctx)
+      throws ResourceAdapterInternalException
+   {
+      log.trace("start()");
+   }
+
+   /**
+    * This is called when a resource adapter instance is undeployed or
+    * during application server shutdown. 
+    */
+   public void stop()
+   {
+      log.trace("stop()");
+   }
+
+   /**
+    * This method is called by the application server during crash recovery.
+    *
+    * @param specs An array of ActivationSpec JavaBeans 
+    * @throws ResourceException generic exception 
+    * @return An array of XAResource objects
+    */
+   public XAResource[] getXAResources(ActivationSpec[] specs)
+      throws ResourceException
+   {
+      log.trace("getXAResources()");
+      return null;
+   }
+
+   /** 
+    * Returns a hash code value for the object.
+    * @return A hash code value for this object.
+    */
+   @Override
+   public int hashCode()
+   {
+      int result = 17;
+      if (enable != null)
+         result += 31 * result + 7 * enable.hashCode();
+      else
+         result += 31 * result + 7;
+      if (localTransaction != null)
+         result += 31 * result + 7 * localTransaction.hashCode();
+      else
+         result += 31 * result + 7;
+      if (xaTransaction != null)
+         result += 31 * result + 7 * xaTransaction.hashCode();
+      else
+         result += 31 * result + 7;
+      return result;
+   }
+
+   /** 
+    * Indicates whether some other object is equal to this one.
+    * @param other The reference object with which to compare.
+    * @return true if this object is the same as the obj argument, false otherwise.
+    */
+   @Override
+   public boolean equals(Object other)
+   {
+      if (other == null)
+         return false;
+      if (other == this)
+         return true;
+      if (!(other instanceof LazyResourceAdapter))
+         return false;
+      LazyResourceAdapter obj = (LazyResourceAdapter)other;
+      boolean result = true; 
+      if (result)
+      {
+         if (enable == null)
+            result = obj.getEnable() == null;
+         else
+            result = enable.equals(obj.getEnable());
+      }
+      if (result)
+      {
+         if (localTransaction == null)
+            result = obj.getLocalTransaction() == null;
+         else
+            result = localTransaction.equals(obj.getLocalTransaction());
+      }
+      if (result)
+      {
+         if (xaTransaction == null)
+            result = obj.getXATransaction() == null;
+         else
+            result = xaTransaction.equals(obj.getXATransaction());
+      }
+      return result;
+   }
+}

--- a/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyXAResource.java
+++ b/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyXAResource.java
@@ -1,0 +1,141 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.ironjacamar.rars.lazy;
+
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Lazy XAResource
+ */
+public class LazyXAResource implements XAResource
+{
+   /** The logger */
+   private static Logger log = Logger.getLogger(LazyXAResource.class);
+
+   /** The managed connection */
+   private LazyManagedConnection mc;
+
+   /**
+    * Constructor
+    * @param mc The managed connection
+    */
+   public LazyXAResource(LazyManagedConnection mc)
+   {
+      this.mc = mc;
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   public void commit(Xid xid, boolean onePhase) throws XAException
+   {
+      log.tracef("commit(%s, %s)", xid, onePhase);
+      mc.setEnlisted(false);
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   public void end(Xid xid, int flags) throws XAException
+   {
+      log.tracef("end(%s, %s)", xid, flags);
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   public void forget(Xid xid) throws XAException
+   {
+      log.tracef("forget(%s)", xid);
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   public int getTransactionTimeout() throws XAException
+   {
+      log.tracef("getTransactionTimeout()");
+      return 0;
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   public boolean isSameRM(XAResource xares) throws XAException
+   {
+      log.tracef("isSameRM(%s)", xares);
+      
+      if (xares != null)
+         return xares instanceof LazyXAResource;
+
+      return false;
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   public int prepare(Xid xid) throws XAException
+   {
+      log.tracef("prepare(%s)", xid);
+      return XAResource.XA_OK;
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   public Xid[] recover(int flag) throws XAException
+   {
+      log.tracef("recover(%s)", flag);
+      return new Xid[] {};
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   public void rollback(Xid xid) throws XAException
+   {
+      log.tracef("rollback(%s)", xid);
+      mc.setEnlisted(false);
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   public boolean setTransactionTimeout(int seconds) throws XAException
+   {
+      log.tracef("setTransactionTimeout(%s)", seconds);
+      return true;
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   public void start(Xid xid, int flags) throws XAException
+   {
+      log.tracef("start(%s, %s)", xid, flags);
+      mc.setEnlisted(true);
+   }
+}

--- a/testsuite/src/test/java/org/ironjacamar/rars/lazy/package-info.java
+++ b/testsuite/src/test/java/org/ironjacamar/rars/lazy/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2016, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the Eclipse Public License 1.0 as
+ * published by the Free Software Foundation.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse
+ * Public License for more details.
+ *
+ * You should have received a copy of the Eclipse Public License 
+ * along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+/**
+ * A resource adapter for testing lazy connection association
+ */
+package org.ironjacamar.rars.lazy;


### PR DESCRIPTION
This commit adds support for the lazy connection manager configurations. The IronJacamar API from the 1.x series was kept.

Once a transaction is started the connection listener will be associated with that transaction, although not enlisted until requested. This is under the assumption that the connection listener will be enlisted at some point during the transaction using ```lazyEnlist()```.

This means that associated connection listeners won't move between threads no matter if they are enlisted or not. This would require resource adapter to use the special IronJacamar API anyway, so we will keep that use-case until we run into actual use-cases where having the extra functionality of moving connection listeners between threads.

Currently the code is focused on the simple and specification related use-cases, as shown by the test cases.