### PR TITLE
 Deprecated elements should have both the annotation and the Javadoc tag

### DIFF
--- a/api/src/main/java/javax/resource/ResourceException.java
+++ b/api/src/main/java/javax/resource/ResourceException.java
@@ -169,6 +169,7 @@ public class ResourceException extends Exception
     * <code>initCause</code> methods of the 
     * <code>java.lang.Throwable</code> class..
     */
+   @Deprecated
    public Exception getLinkedException() 
    {
       return linkedException;
@@ -185,6 +186,7 @@ public class ResourceException extends Exception
     * <code>initCause</code> methods of the 
     * <code>java.lang.Throwable</code> class.
     */
+   @Deprecated
    public void setLinkedException(Exception ex) 
    {
       linkedException = ex;

--- a/api/src/main/java/javax/resource/cci/ResourceWarning.java
+++ b/api/src/main/java/javax/resource/cci/ResourceWarning.java
@@ -131,6 +131,7 @@ public class ResourceWarning extends javax.resource.ResourceException
     * <code>initCause</code> methods of the 
     * <code>java.lang.Throwable</code> class.
     */
+   @Deprecated
    public ResourceWarning getLinkedWarning() 
    {
       try 
@@ -154,6 +155,7 @@ public class ResourceWarning extends javax.resource.ResourceException
     * <code>initCause</code> methods of the 
     * <code>java.lang.Throwable</code> class.
     */
+   @Deprecated
    public void setLinkedWarning(ResourceWarning warning) 
    {
       setLinkedException(warning);

--- a/api/src/main/java/javax/resource/spi/security/GenericCredential.java
+++ b/api/src/main/java/javax/resource/spi/security/GenericCredential.java
@@ -58,7 +58,7 @@ import javax.resource.spi.SecurityException;
  *  is via the <code>org.ietf.jgss.GSSCredential</code> interface in 
  *  J2SE Version 1.4, which provides similar functionality.
  */
-
+@Deprecated
 public interface GenericCredential 
 {
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:MissingDeprecatedCheck - “ Deprecated elements should have both the annotation and the Javadoc tag ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:MissingDeprecatedCheck
Please let me know if you have any questions.
Ayman Abdelghany.