### PR TITLE
"return" statements should not occur in "finally" blocks

### DIFF
--- a/testsuite/src/test/java/org/ironjacamar/perf/Performance.java
+++ b/testsuite/src/test/java/org/ironjacamar/perf/Performance.java
@@ -366,26 +366,27 @@ public abstract class Performance
 
             if (ut != null)
             {
-               int status = ut.getStatus();
-               if (status == Status.STATUS_ACTIVE || status == Status.STATUS_MARKED_ROLLBACK)
+               try
                {
-                  try
+                  int status = ut.getStatus();
+                  if (status == Status.STATUS_ACTIVE || status == Status.STATUS_MARKED_ROLLBACK)
                   {
                      ut.rollback();
                   }
-                  catch (Exception inner)
-                  {
-                     System.err.println("Rollback: Thread: " + Thread.currentThread().getName());
-                     inner.printStackTrace(System.err);
-                  }
                }
+               catch (Exception inner)
+               {
+                  System.err.println("Rollback: Thread: " + Thread.currentThread().getName());
+                  inner.printStackTrace(System.err);
+               }
+            
             }
          }
          finally
          {
             done.countDown();
-            return Integer.valueOf(success);
          }
+         return Integer.valueOf(success);
       }
    }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1143 - “"return" statements should not occur in "finally" blocks”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1143
Please let me know if you have any questions.
Ayman Abdelghany.