### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/common/src/main/java/org/ironjacamar/common/api/metadata/CopyUtil.java
+++ b/common/src/main/java/org/ironjacamar/common/api/metadata/CopyUtil.java
@@ -35,6 +35,9 @@ import java.util.List;
 public class CopyUtil
 {
 
+   private CopyUtil() {
+   }
+
    /**
     *
     * clone a list of IdDecoratedMetadata and deep into the elements

--- a/common/src/main/java/org/ironjacamar/common/api/metadata/MergeUtil.java
+++ b/common/src/main/java/org/ironjacamar/common/api/metadata/MergeUtil.java
@@ -36,6 +36,9 @@ import java.util.Set;
  */
 public class MergeUtil
 {
+   private MergeUtil() {
+   }
+
    /**
     *
     * Merge to List. The results is the union of the two arrays. Element present in left and right List

--- a/common/src/main/java/org/ironjacamar/common/metadata/common/StringUtils.java
+++ b/common/src/main/java/org/ironjacamar/common/metadata/common/StringUtils.java
@@ -35,6 +35,9 @@ public class StringUtils
    /** a tag for map keys */
    private static String endTag = "<%&?>";
 
+   private StringUtils() {
+   }
+
    /**
     * Restores expression with substituted default value
     * @param m a Map with expressions

--- a/common/src/main/java/org/ironjacamar/common/metadata/merge/Merger.java
+++ b/common/src/main/java/org/ironjacamar/common/metadata/merge/Merger.java
@@ -675,6 +675,9 @@ public class Merger
     */
    protected static class ConfigPropertyFactory
    {
+      private ConfigPropertyFactory() {
+      }
+
       /**
        *
        * create a config property from a prototype

--- a/common/src/main/java/org/ironjacamar/common/spi/annotations/repository/AnnotationScannerFactory.java
+++ b/common/src/main/java/org/ironjacamar/common/spi/annotations/repository/AnnotationScannerFactory.java
@@ -52,6 +52,9 @@ public class AnnotationScannerFactory
       }
    }
 
+   private AnnotationScannerFactory() {
+   }
+
    /**
     * Register an annotation scanner
     * @param scanner The scanner

--- a/core/src/main/java/org/ironjacamar/core/connectionmanager/pool/ManagedConnectionPoolUtility.java
+++ b/core/src/main/java/org/ironjacamar/core/connectionmanager/pool/ManagedConnectionPoolUtility.java
@@ -40,6 +40,9 @@ public class ManagedConnectionPoolUtility
 {
    private static String newLine = SecurityActions.getSystemProperty("line.separator");
 
+   private ManagedConnectionPoolUtility() {
+   }
+
    /**
     * Get the full details of a managed connection pool state
     * @param method The method identifier

--- a/core/src/main/java/org/ironjacamar/core/connectionmanager/pool/capacity/SecurityActions.java
+++ b/core/src/main/java/org/ironjacamar/core/connectionmanager/pool/capacity/SecurityActions.java
@@ -30,6 +30,9 @@ import java.security.PrivilegedAction;
  */
 class SecurityActions
 {
+   private SecurityActions() {
+   }
+
    /**
     * Get the classloader.
     * @param c The class

--- a/core/src/main/java/org/ironjacamar/core/naming/Util.java
+++ b/core/src/main/java/org/ironjacamar/core/naming/Util.java
@@ -39,6 +39,9 @@ class Util
 {
    private static final Logger log = Logger.getLogger(Util.class);
 
+   private Util() {
+   }
+
    /**
     * Create a subcontext including any intermediate contexts.
     * @param ctx the parent JNDI Context under which value will be bound

--- a/core/src/main/java/org/ironjacamar/core/tracer/SecurityActions.java
+++ b/core/src/main/java/org/ironjacamar/core/tracer/SecurityActions.java
@@ -31,6 +31,9 @@ import java.security.PrivilegedAction;
  */
 class SecurityActions
 {
+   private SecurityActions() {
+   }
+
    /**
     * Get a system property
     * @param name The property name

--- a/core/src/main/java/org/ironjacamar/core/tracer/Tracer.java
+++ b/core/src/main/java/org/ironjacamar/core/tracer/Tracer.java
@@ -79,7 +79,10 @@ public class Tracer
          }
       }
    }
-   
+
+   private Tracer() {
+   }
+
    /**
     * Is enabled
     * @return The value

--- a/core/src/main/java/org/ironjacamar/core/workmanager/WorkManagerUtil.java
+++ b/core/src/main/java/org/ironjacamar/core/workmanager/WorkManagerUtil.java
@@ -41,6 +41,9 @@ import javax.resource.spi.work.WorkContextProvider;
  */
 public class WorkManagerUtil
 {
+   private WorkManagerUtil() {
+   }
+
    /**
     *
     * Utility method to decide if a work will have to run under long running thread pool

--- a/eis/src/main/java/org/ironjacamar/eis/SecurityActions.java
+++ b/eis/src/main/java/org/ironjacamar/eis/SecurityActions.java
@@ -31,6 +31,9 @@ import java.security.PrivilegedAction;
  */
 class SecurityActions
 {
+   private SecurityActions() {
+   }
+
    /**
     * Get the classloader.
     * @param c The class

--- a/validator/src/main/java/org/ironjacamar/validator/Validation.java
+++ b/validator/src/main/java/org/ironjacamar/validator/Validation.java
@@ -69,6 +69,9 @@ public class Validation
 
    private static final int OTHER = 2;
 
+   private Validation() {
+   }
+
    /**
     * validate
     * @param url The url

--- a/validator/src/main/java/org/ironjacamar/validator/rules/ConfigPropertiesHelper.java
+++ b/validator/src/main/java/org/ironjacamar/validator/rules/ConfigPropertiesHelper.java
@@ -71,6 +71,9 @@ public class ConfigPropertiesHelper
       WARNING_TYPES.add(short.class);
    }
 
+   private ConfigPropertiesHelper() {
+   }
+
    /**
     * validate ConfigProperties type
     *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.