### PR TITLE
Local Variables should not be declared and then immediately returned or thrown

### DIFF
--- a/core/src/main/java/org/ironjacamar/core/workmanager/transport/remote/socket/SocketTransport.java
+++ b/core/src/main/java/org/ironjacamar/core/workmanager/transport/remote/socket/SocketTransport.java
@@ -281,12 +281,10 @@ public class SocketTransport extends AbstractRemoteTransport<String> implements 
                return parameters[0];
             }
             case WORK_EXCEPTION : {
-               WorkException we = (WorkException)parameters[0];
-               throw we;
+               throw (WorkException)parameters[0];
             }
             case GENERIC_EXCEPTION : {
-               Throwable t = (Throwable)parameters[0];
-               throw t;
+               throw (Throwable)parameters[0];
             }
             default :
                if (log.isDebugEnabled())

--- a/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyManagedConnectionFactory.java
+++ b/testsuite/src/test/java/org/ironjacamar/rars/lazy/LazyManagedConnectionFactory.java
@@ -196,8 +196,7 @@ public class LazyManagedConnectionFactory implements ManagedConnectionFactory, R
    @Override
    public int hashCode()
    {
-      int result = 17;
-      return result;
+      return 17;
    }
 
    /** 
@@ -215,7 +214,6 @@ public class LazyManagedConnectionFactory implements ManagedConnectionFactory, R
       if (!(other instanceof LazyManagedConnectionFactory))
          return false;
       LazyManagedConnectionFactory obj = (LazyManagedConnectionFactory)other;
-      boolean result = true; 
-      return result;
+      return true;
    }
 }

--- a/testsuite/src/test/java/org/ironjacamar/rars/security/UnifiedSecurityManagedConnectionFactory.java
+++ b/testsuite/src/test/java/org/ironjacamar/rars/security/UnifiedSecurityManagedConnectionFactory.java
@@ -265,8 +265,7 @@ public class UnifiedSecurityManagedConnectionFactory implements ManagedConnectio
    @Override
    public int hashCode()
    {
-      int result = 17;
-      return result;
+      return 17;
    }
 
    /**
@@ -284,8 +283,7 @@ public class UnifiedSecurityManagedConnectionFactory implements ManagedConnectio
          return true;
       if (!(other instanceof UnifiedSecurityManagedConnectionFactory))
          return false;
-      boolean result = true;
-      return result;
+      return true;
    }
 
    /**

--- a/testsuite/src/test/java/org/ironjacamar/rars/security/UnifiedSecurityResourceAdapter.java
+++ b/testsuite/src/test/java/org/ironjacamar/rars/security/UnifiedSecurityResourceAdapter.java
@@ -129,8 +129,7 @@ public class UnifiedSecurityResourceAdapter implements ResourceAdapter, java.io.
    @Override
    public int hashCode()
    {
-      int result = 17;
-      return result;
+      return 17;
    }
 
    /**
@@ -148,8 +147,7 @@ public class UnifiedSecurityResourceAdapter implements ResourceAdapter, java.io.
          return true;
       if (!(other instanceof UnifiedSecurityResourceAdapter))
          return false;
-      boolean result = true;
-      return result;
+      return true;
    }
 
 }

--- a/testsuite/src/test/java/org/ironjacamar/rars/wm/WorkManagedConnectionFactory.java
+++ b/testsuite/src/test/java/org/ironjacamar/rars/wm/WorkManagedConnectionFactory.java
@@ -169,8 +169,7 @@ public class WorkManagedConnectionFactory implements ManagedConnectionFactory, R
    @Override
    public int hashCode()
    {
-      int result = 17;
-      return result;
+      return 17;
    }
 
    /** 
@@ -188,8 +187,7 @@ public class WorkManagedConnectionFactory implements ManagedConnectionFactory, R
       if (!(other instanceof WorkManagedConnectionFactory))
          return false;
       WorkManagedConnectionFactory obj = (WorkManagedConnectionFactory)other;
-      boolean result = true; 
-      return result;
+      return true;
    }
 
 }

--- a/testsuite/src/test/java/org/ironjacamar/rars/wm/WorkResourceAdapter.java
+++ b/testsuite/src/test/java/org/ironjacamar/rars/wm/WorkResourceAdapter.java
@@ -124,8 +124,7 @@ public class WorkResourceAdapter implements ResourceAdapter, java.io.Serializabl
    @Override
    public int hashCode()
    {
-      int result = 17;
-      return result;
+      return 17;
    }
 
    /** 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1488 - “Local Variables should not be declared and then immediately returned or thrown”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1488
Please let me know if you have any questions.
Ayman Abdelghany.