### PR TITLE
use Java collection interfaces rather than specific implementation

### DIFF
--- a/common/src/main/java/org/ironjacamar/common/metadata/common/AbstractParser.java
+++ b/common/src/main/java/org/ironjacamar/common/metadata/common/AbstractParser.java
@@ -351,7 +351,7 @@ public abstract class AbstractParser
       FlushStrategy flushStrategy = Defaults.FLUSH_STRATEGY;
       Capacity capacity = null;
 
-      HashMap<String, String> expressions = new HashMap<String, String>();
+      Map<String, String> expressions = new HashMap<String, String>();
 
       for (int i = 0; i < reader.getAttributeCount(); i++)
       {
@@ -454,7 +454,7 @@ public abstract class AbstractParser
       Boolean padXid = Defaults.PAD_XID;
       Boolean wrapXaDataSource = Defaults.WRAP_XA_RESOURCE;
 
-      HashMap<String, String> expressions = new HashMap<String, String>();
+      Map<String, String> expressions = new HashMap<String, String>();
 
       for (int i = 0; i < reader.getAttributeCount(); i++)
       {
@@ -565,7 +565,7 @@ public abstract class AbstractParser
 
       String securityDomain = null;
 
-      HashMap<String, String> expressions = new HashMap<String, String>();
+      Map<String, String> expressions = new HashMap<String, String>();
 
       while (reader.hasNext())
       {
@@ -628,7 +628,7 @@ public abstract class AbstractParser
    {
       String securityDomain = null;
 
-      HashMap<String, String> expressions = new HashMap<String, String>();
+      Map<String, String> expressions = new HashMap<String, String>();
 
       while (reader.hasNext())
       {
@@ -682,7 +682,7 @@ public abstract class AbstractParser
       Credential security = null;
       Extension plugin = null;
 
-      HashMap<String, String> expressions = new HashMap<String, String>();
+      Map<String, String> expressions = new HashMap<String, String>();
 
       for (int i = 0; i < reader.getAttributeCount(); i++)
       {
@@ -755,7 +755,7 @@ public abstract class AbstractParser
       String moduleName = null;
       String moduleSlot = null;
       Map<String, String> properties = null;
-      HashMap<String, String> expressions = new HashMap<String, String>();
+      Map<String, String> expressions = new HashMap<String, String>();
 
       for (int i = 0; i < reader.getAttributeCount(); i++)
       {
@@ -893,7 +893,7 @@ public abstract class AbstractParser
       Boolean backgroundValidation = Defaults.BACKGROUND_VALIDATION;
       Long backgroundValidationMillis = null;
 
-      HashMap<String, String> expressions = new HashMap<String, String>();
+      Map<String, String> expressions = new HashMap<String, String>();
 
       while (reader.hasNext())
       {
@@ -964,7 +964,7 @@ public abstract class AbstractParser
       Integer allocationRetry = null;
       Integer xaResourceTimeout = null;
 
-      HashMap<String, String> expressions = new HashMap<String, String>();
+      Map<String, String> expressions = new HashMap<String, String>();
 
       while (reader.hasNext())
       {

--- a/common/src/main/java/org/ironjacamar/common/metadata/ds/DsParser.java
+++ b/common/src/main/java/org/ironjacamar/common/metadata/ds/DsParser.java
@@ -246,7 +246,7 @@ public class DsParser extends AbstractParser implements MetadataParser<DataSourc
       Integer minorVersion = null;
       String module = null;
 
-      HashMap<String, String> expressions = new HashMap<String, String>();
+      Map<String, String> expressions = new HashMap<String, String>();
       
       for (int i = 0; i < reader.getAttributeCount(); i++)
       {
@@ -342,7 +342,7 @@ public class DsParser extends AbstractParser implements MetadataParser<DataSourc
       String securityDomain = null;
       Extension reauthPlugin = null;
 
-      HashMap<String, String> expressions = new HashMap<String, String>();
+      Map<String, String> expressions = new HashMap<String, String>();
 
       while (reader.hasNext())
       {
@@ -419,7 +419,7 @@ public class DsParser extends AbstractParser implements MetadataParser<DataSourc
       Extension validConnectionChecker = null;
       Extension exceptionSorter = null;
 
-      HashMap<String, String> expressions = new HashMap<String, String>();
+      Map<String, String> expressions = new HashMap<String, String>();
       
       while (reader.hasNext())
       {
@@ -520,7 +520,7 @@ public class DsParser extends AbstractParser implements MetadataParser<DataSourc
       Long useTryLock = null;
       Integer xaResourceTimeout = null;
 
-      HashMap<String, String> expressions = new HashMap<String, String>();
+      Map<String, String> expressions = new HashMap<String, String>();
 
       while (reader.hasNext())
       {
@@ -615,7 +615,7 @@ public class DsParser extends AbstractParser implements MetadataParser<DataSourc
       Boolean sharePreparedStatements = Defaults.SHARE_PREPARED_STATEMENTS;
       TrackStatementsEnum trackStatements = null;
 
-      HashMap<String, String> expressions = new HashMap<String, String>();
+      Map<String, String> expressions = new HashMap<String, String>();
 
       while (reader.hasNext())
       {
@@ -693,7 +693,7 @@ public class DsParser extends AbstractParser implements MetadataParser<DataSourc
       Capacity capacity = null;
       Extension connectionListener = null;
 
-      HashMap<String, String> expressions = new HashMap<String, String>();
+      Map<String, String> expressions = new HashMap<String, String>();
 
       for (int i = 0; i < reader.getAttributeCount(); i++)
       {
@@ -808,7 +808,7 @@ public class DsParser extends AbstractParser implements MetadataParser<DataSourc
       Boolean padXid = Defaults.PAD_XID;
       Boolean wrapXaDataSource = Defaults.WRAP_XA_RESOURCE;
 
-      HashMap<String, String> expressions = new HashMap<String, String>();
+      Map<String, String> expressions = new HashMap<String, String>();
 
       for (int i = 0; i < reader.getAttributeCount(); i++)
       {
@@ -952,7 +952,7 @@ public class DsParser extends AbstractParser implements MetadataParser<DataSourc
       Boolean connectable = Defaults.CONNECTABLE;
       Boolean tracking = Defaults.TRACKING;
 
-      HashMap<String, String> expressions = new HashMap<String, String>();
+      Map<String, String> expressions = new HashMap<String, String>();
 
       for (int i = 0; i < reader.getAttributeCount(); i++)
       {
@@ -1143,7 +1143,7 @@ public class DsParser extends AbstractParser implements MetadataParser<DataSourc
       Boolean connectable = Defaults.CONNECTABLE;
       Boolean tracking = Defaults.TRACKING;
 
-      HashMap<String, String> expressions = new HashMap<String, String>();
+      Map<String, String> expressions = new HashMap<String, String>();
 
       for (int i = 0; i < reader.getAttributeCount(); i++)
       {
@@ -1320,7 +1320,7 @@ public class DsParser extends AbstractParser implements MetadataParser<DataSourc
       Credential security = null;
       Extension plugin = null;
 
-      HashMap<String, String> expressions = new HashMap<String, String>();
+      Map<String, String> expressions = new HashMap<String, String>();
 
       for (int i = 0; i < reader.getAttributeCount(); i++)
       {
@@ -1392,7 +1392,7 @@ public class DsParser extends AbstractParser implements MetadataParser<DataSourc
       String password = null;
       String securityDomain = null;
 
-      HashMap<String, String> expressions = new HashMap<String, String>();
+      Map<String, String> expressions = new HashMap<String, String>();
 
       while (reader.hasNext())
       {

--- a/common/src/main/java/org/ironjacamar/common/metadata/ironjacamar/IronJacamarParser.java
+++ b/common/src/main/java/org/ironjacamar/common/metadata/ironjacamar/IronJacamarParser.java
@@ -136,7 +136,7 @@ public class IronJacamarParser extends CommonIronJacamarParser implements Metada
       Map<String, String> configProperties = null;
       WorkManager workManager = null;
       Boolean isXA = null;
-      HashMap<String, String> expressions = new HashMap<String, String>();
+      Map<String, String> expressions = new HashMap<String, String>();
       
       while (reader.hasNext())
       {

--- a/common/src/main/java/org/ironjacamar/common/metadata/resourceadapter/ActivationsImpl.java
+++ b/common/src/main/java/org/ironjacamar/common/metadata/resourceadapter/ActivationsImpl.java
@@ -38,7 +38,7 @@ public class ActivationsImpl extends AbstractMetadata implements Activations
 
    /** The serialVersionUID */
    private static final long serialVersionUID = 1L;
-   private final ArrayList<Activation> activations;
+   private final List<Activation> activations;
 
    /**
     * Constructor

--- a/common/src/main/java/org/ironjacamar/common/metadata/resourceadapter/ResourceAdapterParser.java
+++ b/common/src/main/java/org/ironjacamar/common/metadata/resourceadapter/ResourceAdapterParser.java
@@ -191,7 +191,7 @@ public class ResourceAdapterParser extends CommonIronJacamarParser implements Me
       WorkManager workmanager = null;
       Boolean isXA = null;
 
-      HashMap<String, String> expressions = new HashMap<String, String>();
+      Map<String, String> expressions = new HashMap<String, String>();
 
       int attributeSize = reader.getAttributeCount();
       for (int i = 0; i < attributeSize; i++)

--- a/core/src/main/java/org/ironjacamar/core/connectionmanager/ccm/CachedConnectionManagerImpl.java
+++ b/core/src/main/java/org/ironjacamar/core/connectionmanager/ccm/CachedConnectionManagerImpl.java
@@ -447,7 +447,7 @@ public class CachedConnectionManagerImpl implements CachedConnectionManager
 
       synchronized (connectionStackTraces)
       {
-         HashMap<String, String> result = new HashMap<String, String>();
+         Map<String, String> result = new HashMap<String, String>();
 
          for (Map.Entry<Object, Throwable> entry : connectionStackTraces.entrySet())
          {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1319 - “Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319
Please let me know if you have any questions.
Ayman Abdelghany.