### PR TITLE
Remove username/password checks for XA recovery connections

### DIFF
--- a/core/src/main/java/org/jboss/jca/core/CoreLogger.java
+++ b/core/src/main/java/org/jboss/jca/core/CoreLogger.java
@@ -569,14 +569,6 @@ public interface CoreLogger extends BasicLogger
    public void exceptionDuringCrashRecoverySubject(String jndiName, String reason, @Cause Throwable t);
    
    /**
-    * No security domain defined for crash recovery
-    * @param jndiName The JNDI name
-    */
-   @LogMessage(level = WARN)
-   @Message(id = 904, value = "No security domain defined for crash recovery: %s")
-   public void noCrashRecoverySecurityDomain(String jndiName);
-
-   /**
     * Subject for crash recovery was null
     * @param jndiName The JNDI name
     */

--- a/deployers/src/main/java/org/jboss/jca/deployers/common/AbstractDsDeployer.java
+++ b/deployers/src/main/java/org/jboss/jca/deployers/common/AbstractDsDeployer.java
@@ -1067,58 +1067,53 @@ public abstract class AbstractDsDeployer
             log.debug("RecoverSecurityDomain=" + recoverSecurityDomain);
          }
 
-         if ((recoverUser != null && !recoverUser.trim().equals("") &&
-              recoverPassword != null && !recoverPassword.trim().equals("")) ||
-             (recoverSecurityDomain != null && !recoverSecurityDomain.trim().equals("")))
+         RecoveryPlugin plugin = null;
+
+         if (recoveryMD != null && recoveryMD.getRecoverPlugin() != null &&
+             recoveryMD.getRecoverPlugin().getClassName() != null)
          {
-            RecoveryPlugin plugin = null;
-
-            if (recoveryMD != null && recoveryMD.getRecoverPlugin() != null &&
-                recoveryMD.getRecoverPlugin().getClassName() != null)
+            List<ConfigProperty> configProperties = new ArrayList<ConfigProperty>(recoveryMD.getRecoverPlugin()
+                                                                                  .getConfigPropertiesMap().size());
+            for (Entry<String, String> property : recoveryMD.getRecoverPlugin().getConfigPropertiesMap()
+                    .entrySet())
             {
-               List<ConfigProperty> configProperties = new ArrayList<ConfigProperty>(recoveryMD.getRecoverPlugin()
-                                                                                     .getConfigPropertiesMap().size());
-               for (Entry<String, String> property : recoveryMD.getRecoverPlugin().getConfigPropertiesMap()
-                       .entrySet())
-               {
-                  ConfigProperty c =
-                     new ConfigPropertyImpl(null,
-                                            new XsdString(property.getKey(), null),
-                                            XsdString.NULL_XSDSTRING,
-                                            new XsdString(property.getValue(), null),
-                                            Boolean.FALSE, Boolean.FALSE, Boolean.FALSE,
-                                            null, false, null, null, null, null);
+               ConfigProperty c =
+                  new ConfigPropertyImpl(null,
+                                         new XsdString(property.getKey(), null),
+                                         XsdString.NULL_XSDSTRING,
+                                         new XsdString(property.getValue(), null),
+                                         Boolean.FALSE, Boolean.FALSE, Boolean.FALSE,
+                                         null, false, null, null, null, null);
 
-                  configProperties.add(c);
-               }
-
-               plugin = (RecoveryPlugin) initAndInject(recoveryMD.getRecoverPlugin().getClassName(),
-                                                       configProperties, cl);
-            }
-            else
-            {
-               plugin = new DefaultRecoveryPlugin();
+               configProperties.add(c);
             }
 
-            XAResourceStatistics xastat = null;
-
-            if (pool.getStatistics() != null && pool.getStatistics() instanceof XAResourceStatistics)
-            {
-               xastat = (XAResourceStatistics)pool.getStatistics();
-            }
-
-            recoveryImpl =
-               getTransactionIntegration().createXAResourceRecovery(mcf,
-                                                                    padXid,
-                                                                    isSameRMOverride,
-                                                                    wrapXAResource,
-                                                                    recoverUser,
-                                                                    recoverPassword,
-                                                                    recoverSecurityDomain,
-                                                                    getSubjectFactory(recoverSecurityDomain),
-                                                                    plugin,
-                                                                    xastat);
+            plugin = (RecoveryPlugin) initAndInject(recoveryMD.getRecoverPlugin().getClassName(),
+                                                    configProperties, cl);
          }
+         else
+         {
+            plugin = new DefaultRecoveryPlugin();
+         }
+
+         XAResourceStatistics xastat = null;
+
+         if (pool.getStatistics() != null && pool.getStatistics() instanceof XAResourceStatistics)
+         {
+            xastat = (XAResourceStatistics)pool.getStatistics();
+         }
+
+         recoveryImpl =
+            getTransactionIntegration().createXAResourceRecovery(mcf,
+                                                                 padXid,
+                                                                 isSameRMOverride,
+                                                                 wrapXAResource,
+                                                                 recoverUser,
+                                                                 recoverPassword,
+                                                                 recoverSecurityDomain,
+                                                                 getSubjectFactory(recoverSecurityDomain),
+                                                                 plugin,
+                                                                 xastat);
       }
 
       if (enableRecovery && getTransactionIntegration().getRecoveryRegistry() != null)


### PR DESCRIPTION
If a user connects to an Oracle database he can store his passwords in a Oracle wallet.
In this case the jdbc connection is created without specification of a username and password. The Oracle implementation of the connection reads the password from the defined wallet in this case.

In ironjacamar this is not possible for recovery connections of XA datasources. The problem is mainly because of null checks for username/password or Subject object. This commit removes these checks.

With the following recovery settings in standalone.xml it was afterwards possible to have the recovery connection connect with the credentials from the Oracle wallet:
`<recovery no-recovery="false"/>`

