### PR TITLE
[JBJCA-1321] Statement.cancel() is not invoked until the statement is completed

### DIFF
--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/WrappedStatement.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/WrappedStatement.java
@@ -753,27 +753,17 @@ public abstract class WrappedStatement extends JBossWrapper implements Statement
     */
    public void cancel() throws SQLException
    {
-      if (doLocking)
-         lock();
+      checkState();
       try
       {
-         checkState();
-         try
-         {
-            if (spy)
-               spyLogger.debugf("%s [%s] cancel()", jndiName, spyLoggingCategory);
-         
-            s.cancel();
-         }
-         catch (Throwable t)
-         {
-            throw checkException(t);
-         }
+         if (spy)
+            spyLogger.debugf("%s [%s] cancel()", jndiName, spyLoggingCategory);
+
+         s.cancel();
       }
-      finally
+      catch (Throwable t)
       {
-         if (doLocking)
-            unlock();
+         throw checkException(t);
       }
    }
 


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/JBJCA-1321

Remove the lock from `WrappedStatement.cancel()`