### PR TITLE
Add protection in DsXmlDeployer to prevent from loading xml resource …

### DIFF
--- a/deployers/src/main/java/org/jboss/jca/deployers/fungal/DsXmlDeployer.java
+++ b/deployers/src/main/java/org/jboss/jca/deployers/fungal/DsXmlDeployer.java
@@ -47,6 +47,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -76,7 +77,7 @@ import com.github.fungal.spi.deployers.Deployment;
  * The -ds.xml deployer for JCA/SJC
  * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
  */
-public final class DsXmlDeployer extends AbstractDsDeployer implements Deployer
+public class DsXmlDeployer extends AbstractDsDeployer implements Deployer
 {
    /** The logger */
    private static DeployersLogger log = Logger.getMessageLogger(DeployersLogger.class, DsXmlDeployer.class.getName());
@@ -170,7 +171,7 @@ public final class DsXmlDeployer extends AbstractDsDeployer implements Deployer
     */
    public boolean accepts(URL url)
    {
-      if (url == null || !(url.toExternalForm().endsWith("-ds.xml")))
+      if (url == null || url.toExternalForm().startsWith("jar") || !(url.toExternalForm().endsWith("-ds.xml")))
          return false;
 
       return true;
@@ -197,7 +198,7 @@ public final class DsXmlDeployer extends AbstractDsDeployer implements Deployer
       InputStream is = null;
       try
       {
-         File f = new File(url.toURI());
+         File f = getFileFromUrl(url);
 
          if (!f.exists())
             throw new IOException("Deployment " + url.toExternalForm() + " doesnt exists");
@@ -327,9 +328,40 @@ public final class DsXmlDeployer extends AbstractDsDeployer implements Deployer
                // Ignore
             }
          }
-
+         
+         cleanTemporaryFiles(url);
          SecurityActions.setThreadContextClassLoader(oldTCCL);
       }
+   }
+   
+   /**
+     * Get File object of URL who locate xml resource
+     * @param url url of the archive
+     * @return a File object pointing of xml resource
+     * @throws URISyntaxException Thrown if the resource adapter cant be found
+     * @throws IOException Thrown if the resource adapter cant be accessible
+     */
+   protected File getFileFromUrl(URL url) throws URISyntaxException, IOException
+   {
+      return new File(url.toURI());
+   }
+    
+   /**
+     * Get IronJacamar Home directory
+     * @return a String object
+     */
+   protected String getIronJacamarHome()
+   {
+      return SecurityActions.getSystemProperty("iron.jacamar.home");
+   }
+    
+   /**
+    * Clean all potential temporary files
+    * @param url url of the archive
+    * @throws DeployException Thrown if the resource cant be cleaned
+    */
+   protected void cleanTemporaryFiles(URL url) throws DeployException
+   {
    }
 
    /**


### PR DESCRIPTION
…in jar file, and add possibility of override this class

As I have done in #559 , I propose this PR to do exactly the same thing for DsXmlDeployer.

My goal is to allow a custom DsXmlDeployer file who Override DsXmlDeployer and manage xml datasource loacted in jar file.