### PR TITLE
[JBJCA-1331] Use connection-url to get database connection when connection properties for datasource-class is empty

### DIFF
--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/local/LocalManagedConnectionFactory.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/local/LocalManagedConnectionFactory.java
@@ -104,7 +104,7 @@ public class LocalManagedConnectionFactory extends BaseWrapperManagedConnectionF
       if (dataSourceClass == null && connectionURL == null && driverClass != null)
          throw new ResourceException(bundle.connectionURLNull());
 
-      if (dataSourceClass != null && connectionProps.size() == 0)
+      if (dataSourceClass != null && connectionProps.size() == 0 && (driverClass == null || connectionURL == null))
           throw new ResourceException(bundle.nonConnectionPropertyDefinedForDatasource(dataSourceClass));
 
       return super.createConnectionFactory(cm);
@@ -308,7 +308,7 @@ public class LocalManagedConnectionFactory extends BaseWrapperManagedConnectionF
       Connection con = null;
       try
       {
-         if (dataSourceClass != null)
+         if (dataSourceClass != null && !copy.isEmpty())
          {
             DataSource d = getDataSource();
             con = d.getConnection(copy.getProperty("user"), copy.getProperty("password"));

--- a/deployers/src/main/java/org/jboss/jca/deployers/DeployersLogger.java
+++ b/deployers/src/main/java/org/jboss/jca/deployers/DeployersLogger.java
@@ -194,4 +194,14 @@ public interface DeployersLogger extends BasicLogger
    @LogMessage(level = INFO)
    @Message(id = 20019, value = "Changed TransactionSupport for %s")
    public void changedTransactionSupport(String jndiName);
+
+   /**
+    * Connection Properties for DataSource is empty.
+    *
+    * @param jndiName The JNDI name
+    * @param connURL  The connection URL
+    */
+   @LogMessage(level = WARN)
+   @Message(id = 20020, value = "Connection Properties for DataSource: '%s' is empty, try to use driver-class: '%s' and connection-url: '%s' to connect database")
+   public void connectionPropertiesEmpty(String jndiName, String driverClass, String connURL);
 }

--- a/deployers/src/main/java/org/jboss/jca/deployers/common/AbstractDsDeployer.java
+++ b/deployers/src/main/java/org/jboss/jca/deployers/common/AbstractDsDeployer.java
@@ -756,6 +756,9 @@ public abstract class AbstractDsDeployer
          pp.prefill(subject, null, false);
       }
 
+      if (ds.getDataSourceClass() != null && ds.getConnectionProperties().isEmpty() && ds.getConnectionUrl() != null)
+          getLogger().connectionPropertiesEmpty(jndiName, ds.getDriverClass(), ds.getConnectionUrl());
+
       // ConnectionFactory
       return mcf.createConnectionFactory(cm);
    }


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/JBJCA-1331

PR for 1.2 branch