### PR TITLE
JBJCA-1338 CheckValidConnectionSQL can open a transaction

### DIFF
--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/BaseWrapperManagedConnectionFactory.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/BaseWrapperManagedConnectionFactory.java
@@ -1081,6 +1081,7 @@ public abstract class BaseWrapperManagedConnectionFactory
             Connection c = null;
             try
             {
+               mc.checkTransaction(); // this prevents connection validator from opening a transaction (JBJCA-1338)
                c = mc.getRealConnection();
                SQLException e = isValidConnection(c);
 


### PR DESCRIPTION
...preventing application from changing transaction isolation level (PostgreSQL)

https://issues.jboss.org/browse/JBJCA-1338
https://issues.jboss.org/browse/WFLY-8032
https://issues.jboss.org/browse/JBEAP-8694

Second try...