### PR TITLE
[JBJCA-1353] Parallelize destruction of managed connections

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -130,8 +130,8 @@
   <property name="version.apache-logging" value="1.1.0.jboss"/>
   <property name="version.apiviz" value="1.3.2.GA"/>
   <property name="version.arquillian" value="1.0.2.Final"/>
-  <property name="version.arquillian.byteman" value="1.0.0.Alpha2"/>
-  <property name="version.byteman" value="2.1.2"/>
+  <property name="version.arquillian.byteman" value="1.0.0.Alpha4"/>
+  <property name="version.byteman" value="3.0.10"/>
   <property name="version.dom4j" value="1.6.1"/>
   <property name="version.dtd-parser" value="1.1"/>
   <property name="version.eclipse.ecj" value="3.5.1"/>

--- a/core/src/main/java/org/jboss/jca/core/connectionmanager/pool/mcp/SemaphoreConcurrentLinkedDequeManagedConnectionPool.java
+++ b/core/src/main/java/org/jboss/jca/core/connectionmanager/pool/mcp/SemaphoreConcurrentLinkedDequeManagedConnectionPool.java
@@ -869,19 +869,14 @@ public class SemaphoreConcurrentLinkedDequeManagedConnectionPool implements Mana
       // We need to destroy some connections
       if (destroy != null) 
       {
-         for (ConnectionListenerWrapper clw : destroy) 
-         {
-            log.tracef("Destroying flushed connection %s", clw.getConnectionListener());
-
+         destroy.parallelStream().forEach(clw -> {
             if (Tracer.isEnabled())
                Tracer.destroyConnectionListener(pool.getName(), this, clw.getConnectionListener(),
-                                                false, false, false, true, false, false, false,
-                                                Tracer.isRecordCallstacks() ?
-                                                new Throwable("CALLSTACK") : null);
-                     
+                       false, false, false, true, false, false, false,
+                       Tracer.isRecordCallstacks() ?
+                               new Throwable("CALLSTACK") : null);
             doDestroy(clw);
-            clw = null;
-         }
+         });
       }
 
       // Trigger prefill


### PR DESCRIPTION
In flush(), parallelize the destruction of every
ConnectionListenerWrapper instead of doing them sequentially so that the
total time to flush the pool is reduced.

JIRA: https://issues.jboss.org/browse/JBJCA-1353