### PR TITLE
[JBJCA-1355][JBEAP-13299] set-tx-query-timeout does not work when the…

### DIFF
--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/WrapperDataSource.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/WrapperDataSource.java
@@ -202,9 +202,12 @@ public class WrapperDataSource extends JBossWrapper implements Referenceable, Da
             // No timeout
             if (timeout == -1)
                return -1;
+            // No remaining transaction timeout. This is a very rare case but possible to happen.
+            if (timeout == 0)
+               throw new SQLException(bundle.transactionCannotProceed("No remaining transaction timeout"));
             // Round up to the nearest second
             long result = timeout / 1000;
-            if ((result % 1000) != 0)
+            if ((timeout % 1000) != 0)
                ++result;
             return (int) result;
          }


### PR DESCRIPTION
… remaining transaction timeout is shorter than one second

Incorrect round-up causes returning an incorrect remaining transaction
timeout value and it causes set-tx-query-timeout does not work.

WrapperDataSource#getTimeLeftBeforeTransactionTimeout() returns an
incorrect remaining trancation timeout value 0 when it is shorter
than one second (0-999 millis). It should return 1 in that case.

And it should throw SQLException if the remaining transaction timeout
is exact 0 as there's no room to continue transactional operation in
such case. Of course, this would be a rare case but possible to happen.