### PR TITLE
Add javac.encoding=UTF-8 to javac

### DIFF
--- a/adapters/build.xml
+++ b/adapters/build.xml
@@ -42,7 +42,8 @@
            deprecation="${javac.deprecation}"
            optimize="${javac.optimize}"
            excludes="**/jdk6/**,**/jdk7/**,**/mail/**"
-           includeAntRuntime="false">
+           includeAntRuntime="false"
+ 	       encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
     </javac> 
   </target>
@@ -55,7 +56,8 @@
            deprecation="${javac.deprecation}"
            optimize="${javac.optimize}"
            includes="**/mail/**"
-           includeAntRuntime="false">
+           includeAntRuntime="false"
+ 	       encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
     </javac> 
   </target>
@@ -68,7 +70,8 @@
            deprecation="${javac.deprecation}"
            optimize="${javac.optimize}"
            includes="**/jdk6/**"
-           includeAntRuntime="false">
+           includeAntRuntime="false"
+ 	       encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
     </javac> 
   </target>
@@ -81,7 +84,8 @@
            deprecation="${javac.deprecation}"
            optimize="${javac.optimize}"
            includes="**/jdk7/**"
-           includeAntRuntime="false">
+           includeAntRuntime="false"
+ 	       encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
     </javac> 
   </target>

--- a/adapters/build.xml
+++ b/adapters/build.xml
@@ -43,7 +43,7 @@
            optimize="${javac.optimize}"
            excludes="**/jdk6/**,**/jdk7/**,**/mail/**"
            includeAntRuntime="false"
- 	       encoding="${javac.encoding}">
+           encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
     </javac> 
   </target>
@@ -57,7 +57,7 @@
            optimize="${javac.optimize}"
            includes="**/mail/**"
            includeAntRuntime="false"
- 	       encoding="${javac.encoding}">
+           encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
     </javac> 
   </target>
@@ -71,7 +71,7 @@
            optimize="${javac.optimize}"
            includes="**/jdk6/**"
            includeAntRuntime="false"
- 	       encoding="${javac.encoding}">
+           encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
     </javac> 
   </target>
@@ -85,7 +85,7 @@
            optimize="${javac.optimize}"
            includes="**/jdk7/**"
            includeAntRuntime="false"
- 	       encoding="${javac.encoding}">
+           encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
     </javac> 
   </target>
@@ -202,7 +202,7 @@
       <sysproperty key="test.dir" value="${test.dir}"/>
       <sysproperty key="xb.builder.useUnorderedSequence" value="true"/>
       <sysproperty key="java.naming.factory.initial" value="org.jnp.interfaces.LocalOnlyContextFactory"/>
-    	<sysproperty key="java.naming.factory.url.pkgs" value="org.jboss.naming:org.jnp.interfaces"/>
+      <sysproperty key="java.naming.factory.url.pkgs" value="org.jboss.naming:org.jnp.interfaces"/>
 
       
       <classpath>
@@ -261,7 +261,7 @@
         <pathelement location="${build.adapters.dir}"/>
         <fileset dir="${target.dir}" includes="*.jar"/>
         <fileset dir="${build.adapters.dir}" includes="*.jar"/>
-	     <fileset dir="${lib.dir}/common" includes="*.jar" />
+        <fileset dir="${lib.dir}/common" includes="*.jar" />
         <fileset dir="${lib.dir}/embedded" includes="*.jar" />
         <fileset dir="${lib.dir}/arquillian" includes="*.jar" />
         <fileset dir="${lib.dir}/sjc" includes="*.jar" />
@@ -286,8 +286,8 @@
     <mkdir dir="${build.adapters.dir}/test" />
 
     <path id="adapters.test.lib.path.id">
-	<path refid="test.lib.path.id"/>
-	<pathelement location="${target.dir}/${name}-jdbc.jar"/>		
+    <path refid="test.lib.path.id"/>
+      <pathelement location="${target.dir}/${name}-jdbc.jar"/>        
     </path>
     <javac srcdir="src/test"
            destdir="${build.adapters.dir}/test"
@@ -306,12 +306,12 @@
     <copy todir="${build.adapters.dir}">
       <fileset dir="src/test/resources"/>
     </copy>
-  	
+      
     <copy todir="${build.adapters.dir}/">
       <fileset dir="${target.dir}">
         <include name="jdbc-local.rar"/>
         <include name="jdbc-xa.rar"/>
-	<include name="${name}-jdbc.jar"/>
+        <include name="${name}-jdbc.jar"/>
       </fileset>
     </copy>
   </target>

--- a/api/build.xml
+++ b/api/build.xml
@@ -41,7 +41,7 @@
            deprecation="${javac.deprecation}"
            optimize="${javac.optimize}"
            includeAntRuntime="false"
- 	       encoding="${javac.encoding}">
+           encoding="${javac.encoding}">
       <compilerarg value="-proc:none"/>
     </javac> 
 

--- a/api/build.xml
+++ b/api/build.xml
@@ -40,7 +40,8 @@
            debug="${javac.debug}"
            deprecation="${javac.deprecation}"
            optimize="${javac.optimize}"
-           includeAntRuntime="false">
+           includeAntRuntime="false"
+ 	       encoding="${javac.encoding}">
       <compilerarg value="-proc:none"/>
     </javac> 
 

--- a/build.xml
+++ b/build.xml
@@ -102,6 +102,7 @@
   <property name="javac.debug" value="on" />
   <property name="javac.deprecation" value="on" />
   <property name="javac.optimize" value="off" />
+  <property name="javac.encoding" value="UTF-8" />
 
   <property name="junit.printsummary" value="yes" />
   <property name="junit.haltonerror" value="no" />

--- a/codegenerator/build.xml
+++ b/codegenerator/build.xml
@@ -41,7 +41,8 @@
            debug="${javac.debug}"
            deprecation="${javac.deprecation}"
            optimize="${javac.optimize}"
-           includeAntRuntime="false">
+           includeAntRuntime="false"
+ 	       encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
     </javac> 
   </target>

--- a/common/build.xml
+++ b/common/build.xml
@@ -39,7 +39,8 @@
            deprecation="${javac.deprecation}"
            includes="**/papaki/**"
            optimize="${javac.optimize}"
-           includeAntRuntime="false">
+           includeAntRuntime="false"
+ 	       encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
       <compilerarg value="-AgeneratedTranslationFilesPath=${build.common.dir}"/>
       <compilerarg value="-AtranslationFilesPath=${build.common.dir}"/>
@@ -56,7 +57,8 @@
            deprecation="${javac.deprecation}"
            excludes="**/papaki/**"
            optimize="${javac.optimize}"
-           includeAntRuntime="false">
+           includeAntRuntime="false"
+ 	       encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
       <compilerarg value="-AgeneratedTranslationFilesPath=${build.common.dir}"/>
       <compilerarg value="-AtranslationFilesPath=${build.common.dir}"/>
@@ -68,7 +70,8 @@
            debug="${javac.debug}"
            deprecation="${javac.deprecation}"
            optimize="${javac.optimize}"
-           includeAntRuntime="false">
+           includeAntRuntime="false"
+ 	       encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
     </javac> 
 

--- a/core/build.xml
+++ b/core/build.xml
@@ -41,7 +41,8 @@
            debug="${javac.debug}"
            deprecation="${javac.deprecation}"
            optimize="${javac.optimize}"
-           includeAntRuntime="false">
+           includeAntRuntime="false"
+ 	       encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
       <compilerarg value="-AgeneratedTranslationFilesPath=${build.core.dir}/impl"/>
       <compilerarg value="-AtranslationFilesPath=${build.core.dir}/impl"/>

--- a/deployers/build.xml
+++ b/deployers/build.xml
@@ -39,7 +39,8 @@
            deprecation="${javac.deprecation}"
            includes="**/fungal/**"
            optimize="${javac.optimize}"
-           includeAntRuntime="false">
+           includeAntRuntime="false"
+    	   encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
       <compilerarg value="-AgeneratedTranslationFilesPath=${build.deployers.dir}/impl"/>
       <compilerarg value="-AtranslationFilesPath=${build.deployers.dir}/impl"/>

--- a/deployers/build.xml
+++ b/deployers/build.xml
@@ -57,7 +57,8 @@
            deprecation="${javac.deprecation}"
            excludes="**/fungal/**"
            optimize="${javac.optimize}"
-           includeAntRuntime="false">
+           includeAntRuntime="false"
+           encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
       <compilerarg value="-AgeneratedTranslationFilesPath=${build.deployers.dir}/impl"/>
       <compilerarg value="-AtranslationFilesPath=${build.deployers.dir}/impl"/>
@@ -71,7 +72,8 @@
            debug="${javac.debug}"
            deprecation="${javac.deprecation}"
            optimize="${javac.optimize}"
-           includeAntRuntime="false">
+           includeAntRuntime="false"
+           encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
     </javac> 
 

--- a/embedded/build.xml
+++ b/embedded/build.xml
@@ -47,7 +47,7 @@
            deprecation="${javac.deprecation}"
            optimize="${javac.optimize}"
            includeAntRuntime="false"
- 	       encoding="${javac.encoding}">
+           encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
     </javac> 
   </target>

--- a/embedded/build.xml
+++ b/embedded/build.xml
@@ -46,7 +46,8 @@
            debug="${javac.debug}"
            deprecation="${javac.deprecation}"
            optimize="${javac.optimize}"
-           includeAntRuntime="false">
+           includeAntRuntime="false"
+ 	       encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
     </javac> 
   </target>

--- a/rhq/build.xml
+++ b/rhq/build.xml
@@ -41,7 +41,8 @@
            debug="${javac.debug}"
            deprecation="${javac.deprecation}"
            optimize="${javac.optimize}"
-           includeAntRuntime="false">
+           includeAntRuntime="false"
+ 	       encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
     </javac> 
   </target>

--- a/rhq/build.xml
+++ b/rhq/build.xml
@@ -42,7 +42,7 @@
            deprecation="${javac.deprecation}"
            optimize="${javac.optimize}"
            includeAntRuntime="false"
- 	       encoding="${javac.encoding}">
+           encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
     </javac> 
   </target>

--- a/sjc/build.xml
+++ b/sjc/build.xml
@@ -47,7 +47,7 @@
            deprecation="${javac.deprecation}"
            optimize="${javac.optimize}"
            includeAntRuntime="false"
- 	       encoding="${javac.encoding}">
+           encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
     </javac> 
   </target>

--- a/sjc/build.xml
+++ b/sjc/build.xml
@@ -46,7 +46,8 @@
            debug="${javac.debug}"
            deprecation="${javac.deprecation}"
            optimize="${javac.optimize}"
-           includeAntRuntime="false">
+           includeAntRuntime="false"
+ 	       encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
     </javac> 
   </target>

--- a/validator/build.xml
+++ b/validator/build.xml
@@ -55,7 +55,8 @@
            deprecation="${javac.deprecation}"
            includes="**/cli/**, **/ant/**, **/maven/**"
            optimize="${javac.optimize}"
-           includeAntRuntime="false">
+           includeAntRuntime="false"
+ 	       encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
     </javac> 
   </target>

--- a/validator/build.xml
+++ b/validator/build.xml
@@ -42,7 +42,8 @@
            debug="${javac.debug}"
            deprecation="${javac.deprecation}"
            optimize="${javac.optimize}"
-           includeAntRuntime="false">
+           includeAntRuntime="false"
+           encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
     </javac> 
   </target>
@@ -56,7 +57,7 @@
            includes="**/cli/**, **/ant/**, **/maven/**"
            optimize="${javac.optimize}"
            includeAntRuntime="false"
- 	       encoding="${javac.encoding}">
+           encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
     </javac> 
   </target>

--- a/web/build.xml
+++ b/web/build.xml
@@ -47,7 +47,7 @@
            deprecation="${javac.deprecation}"
            optimize="${javac.optimize}"
            includeAntRuntime="false"
- 	       encoding="${javac.encoding}">
+           encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
     </javac> 
   </target>

--- a/web/build.xml
+++ b/web/build.xml
@@ -46,7 +46,8 @@
            debug="${javac.debug}"
            deprecation="${javac.deprecation}"
            optimize="${javac.optimize}"
-           includeAntRuntime="false">
+           includeAntRuntime="false"
+ 	       encoding="${javac.encoding}">
       <compilerarg value="-Xlint"/>
     </javac> 
   </target>


### PR DESCRIPTION
Add javac.encoding=UTF-8  to avoid compile error on platform where the default encoding is different from UTF-8

Signed-off-by: Francis ANDRE <francis.andre.kampbell@orange.fr>