### PR TITLE
[JBEAP-14103][JBJCA-1367] At WrappedConnection.setManagedConnection, do not reset…

### DIFF
--- a/adapters/src/main/java/org/jboss/jca/adapters/AdaptersBundle.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/AdaptersBundle.java
@@ -362,5 +362,14 @@ public interface AdaptersBundle
     */
    @Message(id = 31103, value = "At least one connection property must be defined for datasource-class: %s")
    public String nonConnectionPropertyDefinedForDatasource(String cls);
+
+   /**
+    * A wrapped connection is being associated with a non-null managed connection while still locked
+    * by another thread. This will only happen if there is a locked thread using
+    * that wrapped connection with a previously associated managed connection. (see JBJCA-1367)
+    * @return The value
+    */
+   @Message(id = 31104, value = "Wrapped connection is still in use by another thread")
+   public String wrappedConnectionInUse();
 }
 

--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/WrappedConnection.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/WrappedConnection.java
@@ -112,16 +112,21 @@ public abstract class WrappedConnection extends JBossWrapper implements Connecti
    void setManagedConnection(final BaseWrapperManagedConnection mc)
    {
       this.mc = mc;
-      this.lockCount = 0;
 
       if (mc != null)
       {
          trackStatements = mc.getTrackStatements();
+         // This will only work because JDBC wrapped connections are not returned to a pool;
+         // only the mc inside the WrappedConnection is returned to the pool.
+         // That means the only moment this method is called with a non-null mc is
+         // during WrappedConnection creation
+         if (lockCount > 0) {
+            throw new IllegalStateException(bundle.wrappedConnectionInUse());
+         }
       }
       else
       {
-         // Reset lockedMC reference once the connection is returned to the pool
-         lockedMC = null;
+         // do not reset lockedMC reference once the connection is returned to the pool (JBJCA-1367)
          closed = true;
       }
    }


### PR DESCRIPTION
… the lockCount and lockedMC fields

Either those fields will be equal to 0 and null respectively, and in this case they are already reset.
Or they will be >0 and non-null. In this case, there is a thread performing a job on this connection that will eventually invoke unlock, and result the fields to be reset automatically when it does so.