### PR TITLE
JBJCA-1378 Use new API to determine remaining transaction timeout

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -175,6 +175,7 @@
   <property name="version.slf4j" value="1.6.1"/>
   <property name="version.transaction.api" value="1.0.0.Final"/>
   <property name="version.validation-api" value="1.1.0.Final"/>
+  <property name="version.wildfly.transaction.client" value="1.0.3.Final"/>
 
   <!-- ================================= 
        Paths              

--- a/core/.classpath
+++ b/core/.classpath
@@ -45,5 +45,6 @@
 	<classpathentry kind="lib" path="/ironjacamar-parent/target/ironjacamar-embedded.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/ironjacamar-arquillian"/>
 	<classpathentry kind="lib" path="/ironjacamar-parent/lib/arquillian/arquillian-test-api.jar"/>
+	<classpathentry kind="lib" path="/ironjacamar-parent/lib/common/wildfly-transaction-client.jar"/>
 	<classpathentry kind="output" path="eclipse-target/classes"/>
 </classpath>

--- a/core/src/main/java/org/jboss/jca/core/connectionmanager/tx/TxConnectionManagerImpl.java
+++ b/core/src/main/java/org/jboss/jca/core/connectionmanager/tx/TxConnectionManagerImpl.java
@@ -35,6 +35,8 @@ import org.jboss.jca.core.spi.transaction.TransactionTimeoutConfiguration;
 import org.jboss.jca.core.spi.transaction.TxUtils;
 import org.jboss.jca.core.spi.transaction.XAResourceStatistics;
 import org.jboss.jca.core.tx.jbossts.XAResourceWrapperStatImpl;
+import org.wildfly.transaction.client.AbstractTransaction;
+import org.wildfly.transaction.client.ContextTransactionManager;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -371,7 +373,7 @@ public class TxConnectionManagerImpl extends AbstractConnectionManager implement
    /**
     * Gets time left.
     * @param errorRollback error rollback
-    * @return time left
+    * @return time left in ms
     * @throws RollbackException if exception
     */
    public long getTimeLeftBeforeTransactionTimeout(boolean errorRollback) throws RollbackException
@@ -386,7 +388,15 @@ public class TxConnectionManagerImpl extends AbstractConnectionManager implement
          return ((TransactionTimeoutConfiguration)transactionManager).
             getTimeLeftBeforeTransactionTimeout(errorRollback);  
       }
-      
+
+      if (transactionManager instanceof ContextTransactionManager)
+      {
+         AbstractTransaction transaction = ((ContextTransactionManager) transactionManager).getTransaction();
+         if (transaction != null) {
+            return transaction.getEstimatedRemainingTime() * 1000;
+         }
+      }
+
       return -1;
    }
 

--- a/ivy.xml
+++ b/ivy.xml
@@ -197,6 +197,7 @@
     <dependency org="org.picketbox" name="picketbox" rev="${version.jboss.picketbox}" conf="as,common,ironjacamar-depchain,ironjacamar-core-impl"/>
     <dependency org="org.slf4j" name="jcl-over-slf4j" rev="${version.slf4j}" conf="common,ironjacamar-depchain"/>
     <dependency org="org.slf4j" name="slf4j-api" rev="${version.slf4j}" conf="common,ironjacamar-depchain"/>
+    <dependency org="org.wildfly.transaction" name="wildfly-transaction-client" rev="${version.wildfly.transaction.client}" conf="as,common,ironjacamar-core-impl"/>
   </dependencies>
 
 </ivy-module>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBJCA-1378
https://issues.jboss.org/browse/JBEAP-13301

According to https://github.com/wildfly/wildfly-transaction-client/pull/38 datasource implementation should be able to use wildfly-transaction-client API to determine remaining transaction timeout, hence I'm adding new dependency.