### PR TITLE
JBJCA-1394 clear (TCCL) mcf classloader reference in getConnection()

### DIFF
--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/WrapperDataSource.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/WrapperDataSource.java
@@ -160,6 +160,7 @@ public class WrapperDataSource extends JBossWrapper implements Referenceable, Da
       }
       finally
       {
+         mcf.setOriginalTCCLn(null); // fix for WFLY-12676 memory leak
          SecurityActions.setThreadContextClassLoader(tccl);
       }
    }


### PR DESCRIPTION
https://issues.jboss.org/browse/JBJCA-1394
https://issues.jboss.org/browse/WFLY-12676 
https://issues.jboss.org/browse/WFLY-12671 (original leak issue reported against WF17, not clear if its the same cause yet or an actual leak yet).