### PR TITLE
use https for maven central

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -80,7 +80,7 @@
   <!-- ================================= 
        Repositories              
        ================================= -->
-  <property name="central.repo" value="http://repo1.maven.org/maven2"/>
+  <property name="central.repo" value="https://repo1.maven.org/maven2"/>
   <property name="jboss.repo" value="https://repository.jboss.org/nexus/content/groups/public/"/>
   <property name="snapshots.repo" value="https://repository.jboss.org/nexus/content/repositories/snapshots/"/>
   <property name="fungal.repo" value="http://jesperpedersen.github.com/fungal/maven2"/>


### PR DESCRIPTION
Maven central moved to HTTPS and returns HTTP 501 on HTTP requests.
https://blog.sonatype.com/central-repository-moving-to-https

IronJacamar build then fails with errors like:
[ivy:retrieve]  SERVER ERROR: HTTPS Required url=http://repo1.maven.org/maven2/org/apache/ant/ant/1.8.1/ant-1.8.1.jar