### PR TITLE
[JBJCA-1404] Prevent pool filler thread to run parallel with test

### DIFF
--- a/core/src/test/java/org/jboss/jca/core/connectionmanager/unit/pool/mcp/SemaphoreArrayListManagedConnectionPoolTestCase.java
+++ b/core/src/test/java/org/jboss/jca/core/connectionmanager/unit/pool/mcp/SemaphoreArrayListManagedConnectionPoolTestCase.java
@@ -126,6 +126,8 @@ public class SemaphoreArrayListManagedConnectionPoolTestCase
    {
       pool.setCapacity(null);
       poolConfig.setPrefill(true);
+      // prevent pool filler thread from running in parallel with the test, fillTo was not designed to be run concurrently
+      poolConfig.setMinSize(0);
       poolConfig.setStrictMin(true);
       SemaphoreArrayListManagedConnectionPool mcp = new SemaphoreArrayListManagedConnectionPool();
       mcp.initialize(mcf, cm, null, null, poolConfig, pool);


### PR DESCRIPTION
This is a followup for previous JBJCA-1404 commits https://github.com/ironjacamar/ironjacamar/pull/701
That PR added new testcase similar to the SemaphoreConcurrentLinkedDequeManagedConnectionPoolTestCase but missed the addition of the workaround for `testFillTo()`
We need the same workaround also for SemaphoreArrayListManagedConnectionPoolTestCase to prevent intermittent race conditions during testing.

After this patch these tests are alike:
SemaphoreConcurrentLinkedDequeManagedConnectionPoolTestCase#testFillTo()
SemaphoreArrayListManagedConnectionPoolTestCase#testFillTo()