### PR TITLE
[JBJCA-1413] TxConnectionListener: Don't throw any exception if recor…

### DIFF
--- a/core/src/main/java/org/jboss/jca/core/connectionmanager/listener/TxConnectionListener.java
+++ b/core/src/main/java/org/jboss/jca/core/connectionmanager/listener/TxConnectionListener.java
@@ -998,7 +998,7 @@ public class TxConnectionListener extends AbstractConnectionListener
                }
                else
                {
-                  enlistError = new Throwable("Failed to enlist");
+                  enlistError = null;
                }
             }
             else


### PR DESCRIPTION
…dEnlist==false

This seems to be a bug to me.
If recordEnlist is set to false, we set exception to:
https://github.com/ironjacamar/ironjacamar/blob/1.4/core/src/main/java/org/jboss/jca/core/connectionmanager/listener/TxConnectionListener.java#L1001
which is latter interpreted by the code as the serious one:
https://github.com/ironjacamar/ironjacamar/blob/1.4/core/src/main/java/org/jboss/jca/core/connectionmanager/listener/TxConnectionListener.java#L941

@maeste  could you please review?