### PR TITLE
Corrected use of MethodHandle to invoke method. Uses Optional.

### DIFF
--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/SecurityActions.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/SecurityActions.java
@@ -146,40 +146,6 @@ class SecurityActions
    }
 
    /**
-    * Get the method
-    * @param c The class
-    * @param name The name
-    * @param params The parameters
-    * @return The method
-    * @exception NoSuchMethodException If a matching method is not found.
-    */
-   static Method getMethod(final Class<?> c, final String name, final Class<?>... params)
-       throws NoSuchMethodException
-   {
-      if (System.getSecurityManager() == null)
-         return c.getMethod(name, params);
-
-      Method result = AccessController.doPrivileged(new PrivilegedAction<Method>()
-      {
-         public Method run()
-         {
-            try
-            {
-               return c.getMethod(name, params);
-            } catch (NoSuchMethodException e)
-            {
-               return null;
-            }
-         }
-      });
-
-      if (result != null)
-         return result;
-
-      throw new NoSuchMethodException();
-   }
-
-   /**
     * Get the void return no arguments signature MethodHandle
     * @param c The class
     * @param name Method name
@@ -190,7 +156,7 @@ class SecurityActions
       if (System.getSecurityManager() == null)
       {
          MethodHandles.Lookup lookup = publicLookup();
-         MethodType type = methodType(Void.class);
+         MethodType type = methodType(void.class);
          try
          {
             return lookup.findVirtual(c, name, type);
@@ -208,7 +174,7 @@ class SecurityActions
                try
                {
                   MethodHandles.Lookup lookup = publicLookup();
-                  MethodType type = methodType(Void.class);
+                  MethodType type = methodType(void.class);
                   return lookup.findVirtual(c, name, type);
                } catch (NoSuchMethodException|IllegalAccessException e)
                {


### PR DESCRIPTION
 This PR looks to fix some typos introduced in #716. Plus reinstate the use of Optional.
 The performance results for JSE8 in this 2nd round are as follows.

```
Benchmark                      Mode  Cnt          Score         Error  Units
JSE8IJBench.methodHandleJDK8  thrpt    5  971785165.970 ± 3814383.265  ops/s
JSE8IJBench.reflectiveJSE8    thrpt    5  972288859.880 ± 4648031.680  ops/s
```
 These results show both MethodHandle and Reflective to be the same as expected.

 For JSE9 these are the results
```
Benchmark                      Mode  Cnt          Score        Error  Units
JSE9IJBench.methodHandleJSE9  thrpt   25  157610604.062 ± 173456.549  ops/s
JSE9IJBench.reflectiveJSE9    thrpt   25  123311938.959 ± 599554.129  ops/s
```
 This shows an improvement using MethodHandle.
