### PR TITLE
[JBJCA-1410] Fix reference caching to match the lifecycle of a ManagedConnection.

### DIFF
--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/BaseWrapperManagedConnection.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/BaseWrapperManagedConnection.java
@@ -30,6 +30,7 @@ import org.jboss.jca.core.spi.transaction.ConnectableResource;
 import org.jboss.jca.core.spi.transaction.ConnectableResourceListener;
 
 import java.io.PrintWriter;
+import java.lang.invoke.MethodHandle;
 import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -39,6 +40,7 @@ import java.sql.Statement;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -132,6 +134,9 @@ public abstract class BaseWrapperManagedConnection implements ManagedConnection,
 
    /** Metadata */
    protected ManagedConnectionMetaData metadata;
+
+   /** optional implementations on the driver*/
+   private Optional<MethodHandle> requestBegin,requestEnd;
 
    static
    {
@@ -1222,6 +1227,25 @@ public abstract class BaseWrapperManagedConnection implements ManagedConnection,
       return lc;
    }
 
+   protected Optional<MethodHandle> getEndRequestNotify()
+   {
+      return requestEnd;
+   }
+
+   protected void setEndRequestNotify(Optional<MethodHandle> endRequest)
+   {
+      requestEnd = endRequest;
+   }
+
+   protected Optional<MethodHandle> getBeginRequestNotify()
+   {
+      return requestBegin;
+   }
+
+   protected void setBeginRequestNotify(Optional<MethodHandle> beginRequest)
+   {
+      requestBegin = beginRequest;
+   }
 
    /**
     * Returns true if the underlying connection is handled by an XA resource manager

--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/SecurityActions.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/SecurityActions.java
@@ -25,7 +25,6 @@ package org.jboss.jca.adapters.jdbc;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 

--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/WrappedConnection.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/WrappedConnection.java
@@ -95,7 +95,6 @@ public abstract class WrappedConnection extends JBossWrapper implements Connecti
    
    private final ClassLoaderPlugin classLoaderPlugin;
 
-   private Optional<MethodHandle> requestBegin,requestEnd;
    /**
     * Constructor
     * @param mc The managed connection
@@ -317,11 +316,10 @@ public abstract class WrappedConnection extends JBossWrapper implements Connecti
          {
             mc.errorHandle(this);
          }
+         sqlConnectionNotifyRequestEnd();
       }
       mc = null;
       dataSource = null;
-
-      sqlConnectionNotifyRequestEnd();
    }
 
    /**
@@ -2142,22 +2140,26 @@ public abstract class WrappedConnection extends JBossWrapper implements Connecti
 
    private void sqlConnectionNotifyRequestBegin()
    {
-      if (requestBegin == null)
+      Optional<MethodHandle> mh = mc.getEndRequestNotify();
+      if (mh == null)
       {
-         requestBegin = lookupNotifyMethod("beginRequest");
+         mh = lookupNotifyMethod("beginRequest");
+         mc.setBeginRequestNotify(mh);
       }
-      if (requestBegin.isPresent())
-         invokeNotifyMethod(requestBegin.get(), "beginRequest");
+      if (mh.isPresent())
+         invokeNotifyMethod(mh.get(), "beginRequest");
    }
 
    private void sqlConnectionNotifyRequestEnd()
    {
-      if (requestEnd == null)
+      Optional<MethodHandle> mh = mc.getEndRequestNotify();
+      if (mh == null)
       {
-         requestEnd = lookupNotifyMethod("endRequest");
+         mh = lookupNotifyMethod("endRequest");
+         mc.setEndRequestNotify(mh);
       }
-      if (requestEnd.isPresent())
-         invokeNotifyMethod(requestEnd.get(), "endRequest");
+      if (mh.isPresent())
+         invokeNotifyMethod(mh.get(), "endRequest");
    }
 
    private Optional<MethodHandle> lookupNotifyMethod(String methodName)


### PR DESCRIPTION
 The current lifecycle of the cached references is associated with the WrappedConnection. This lifecycle is "single use" disposable instance for j.s.Connection users (application code).
 Instead the lifecycle should be associated with the ManagedConnection instance.
 
 This PR makes the necessary changes to ensure the lifecycle of method references remain reachable (caching it). Ensuring the subsequent use of a ManagedConnection can find the cached MethodHandle as originally intended.

 This has been tested to work as expected on JDK8 and JDK9.
