### PR TITLE
[JBJCA-1424] Fungal repo now at jesperpedersen.github.io/fungal/maven2

### DIFF
--- a/codegenerator/src/main/resources/build.gradle.template
+++ b/codegenerator/src/main/resources/build.gradle.template
@@ -18,7 +18,7 @@ repositories {
   mavenRepo name: 'jboss-nexus', url: "http://repository.jboss.org/nexus/content/groups/public/"
   mavenRepo name: "jboss-snapshots", url: "http://snapshots.jboss.org/maven2/"
   mavenCentral()
-  mavenRepo name: 'fungal', url: "http://jesperpedersen.github.com/fungal/maven2/"
+  mavenRepo name: 'fungal', url: "https://jesperpedersen.github.io/fungal/maven2/"
 }
 dependencies {
   compile 'org.jboss.ironjacamar:ironjacamar-spec-api:@IJ_VERSION@'

--- a/codegenerator/src/main/resources/build.ivy.xml.template
+++ b/codegenerator/src/main/resources/build.ivy.xml.template
@@ -52,7 +52,7 @@
   <property name="central.repo" value="http://repo1.maven.org/maven2"/>
   <property name="jboss.repo" value="http://repository.jboss.org/nexus/content/groups/public/"/>
   <property name="snapshots.repo" value="http://repository.jboss.org/nexus/content/repositories/snapshots/"/>
-  <property name="fungal.repo" value="http://jesperpedersen.github.com/fungal/maven2"/>
+  <property name="fungal.repo" value="https://jesperpedersen.github.io/fungal/maven2"/>
 
   <!-- ================================= 
        Versions              

--- a/codegenerator/src/main/resources/pom.xml.template
+++ b/codegenerator/src/main/resources/pom.xml.template
@@ -158,7 +158,7 @@ ${stop.goal}
     </repository>
     <repository>
       <id>fungal</id>
-      <url>http://jesperpedersen.github.com/fungal/maven2</url>
+      <url>https://jesperpedersen.github.io/fungal/maven2</url>
     </repository>
   </repositories>
 </project>

--- a/doc/src/main/asciidoc/developer-guide/chapters/_standalone.adoc
+++ b/doc/src/main/asciidoc/developer-guide/chapters/_standalone.adoc
@@ -60,6 +60,6 @@ $$.$$
 
 The IronJacamar/SJC uses the Fungal kernel for its run-time environment.
 
-The homepage for the Fungal is http://jesperpedersen.github.com/fungal
+The homepage for the Fungal is https://jesperpedersen.github.io/fungal
 
 SJC is short for "Simple JCA Container".


### PR DESCRIPTION
https://issues.redhat.com/browse/JBJCA-1424

TL;DR jesperpedersen.github.com is no longer working, we need to use jesperpedersen.github.io

port of https://github.com/ironjacamar/ironjacamar/pull/721
@tadamski the changes are trivial, I was, however, unable to verify as the current branch seems unbuildable 

