### PR TITLE
Modify validator tests to match current behavior after JBJCA-1416

### DIFF
--- a/validator/src/test/java/org/jboss/jca/validator/rules/ao/AOTestCase.java
+++ b/validator/src/test/java/org/jboss/jca/validator/rules/ao/AOTestCase.java
@@ -226,7 +226,7 @@ public class AOTestCase extends TestCaseAbstract
          //when
          embedded.deploy(archive);
          assertThat(directory.listFiles().length, is(1));
-         assertThat(directory.listFiles()[0].getName(), is("ao_property_wrong.rar.log"));
+         assertThat(directory.listFiles()[0].getName(), is("ao_property_wrong.log"));
          input = new BufferedReader(new FileReader(directory.listFiles()[0]));
          assertThat(input.readLine(), is("Severity: WARNING"));
          assertThat(input.readLine(), is("Section: 20.7"));

--- a/validator/src/test/java/org/jboss/jca/validator/rules/as/ASTestCase.java
+++ b/validator/src/test/java/org/jboss/jca/validator/rules/as/ASTestCase.java
@@ -121,7 +121,7 @@ public class ASTestCase extends TestCaseAbstract
          //when
          embedded.deploy(archive);
          assertThat(directory.listFiles().length, is(1));
-         assertThat(directory.listFiles()[0].getName(), is("as_property_wrong.rar.log"));
+         assertThat(directory.listFiles()[0].getName(), is("as_property_wrong.log"));
          input = new BufferedReader(new FileReader(directory.listFiles()[0]));
          assertThat(input.readLine(), is("Severity: WARNING"));
          assertThat(input.readLine(), is("Section: 20.7"));

--- a/validator/src/test/java/org/jboss/jca/validator/rules/mcf/MCFTestCase.java
+++ b/validator/src/test/java/org/jboss/jca/validator/rules/mcf/MCFTestCase.java
@@ -333,7 +333,7 @@ public class MCFTestCase extends TestCaseAbstract
          //when
          embedded.deploy(archive);
          assertThat(directory.listFiles().length, is(1));
-         assertThat(directory.listFiles()[0].getName(), is("mcf_property_wrong.rar.log"));
+         assertThat(directory.listFiles()[0].getName(), is("mcf_property_wrong.log"));
          input = new BufferedReader(new FileReader(directory.listFiles()[0]));
          assertThat(input.readLine(), is("Severity: WARNING"));
          assertThat(input.readLine(), is("Section: 20.7"));

--- a/validator/src/test/java/org/jboss/jca/validator/rules/ra/RATestCase.java
+++ b/validator/src/test/java/org/jboss/jca/validator/rules/ra/RATestCase.java
@@ -390,7 +390,7 @@ public class RATestCase extends TestCaseAbstract
          //when
          embedded.deploy(archive);
          assertThat(directory.listFiles().length, is(1));
-         assertThat(directory.listFiles()[0].getName(), is("ra_property_wrong.rar.log"));
+         assertThat(directory.listFiles()[0].getName(), is("ra_property_wrong.log"));
          input = new BufferedReader(new FileReader(directory.listFiles()[0]));
          assertThat(input.readLine(), is("Severity: WARNING"));
          assertThat(input.readLine(), is("Section: 20.7"));


### PR DESCRIPTION
https://issues.redhat.com/browse/JBJCA-1416 (https://github.com/ironjacamar/ironjacamar/commit/f683b205ebc19ba4fae1da67adb5c25d6eaf0e4e) changed the name of the log files so we must also update tests checking these particular log files.