### PR TITLE
[JBJCA-1427] user and password should be copied to the properties if they are specified

### DIFF
--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/BaseWrapperManagedConnectionFactory.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/BaseWrapperManagedConnectionFactory.java
@@ -1560,7 +1560,7 @@ public abstract class BaseWrapperManagedConnectionFactory
                         pass = password;
                   }
 
-                  if (copyGssCredentials)
+                  if (cri != null || userName != null || copyGssCredentials)
                   {
                      props.setProperty("user", (user == null) ? "" : user);
                      props.setProperty("password", (pass == null) ? "" : pass);


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBJCA-1427
EAP Issue: https://issues.redhat.com/browse/JBEAP-22286

When `DataSource.getConnection(username, password)` is called, it should use username/password specified in the method call instead of using kerberos username.
