### PR TITLE
Remove MaxPermSize jvm options

### DIFF
--- a/codegenerator/src/main/resources/build.ivy.xml.template
+++ b/codegenerator/src/main/resources/build.ivy.xml.template
@@ -19,7 +19,7 @@
   <property name="junit.fork" value="yes" />
   <property name="junit.timeout" value="60000" />
   <property name="junit.jvm" value="" />
-  <property name="junit.jvm.options" value="-Xms128m -Xmx512m -XX:MaxPermSize=256m" />
+  <property name="junit.jvm.options" value="-Xms128m -Xmx512m"/>
   <property name="junit.batchtest.haltonerror" value="no" />
   <property name="junit.batchtest.haltonfailure" value="no" />
   <property name="junit.batchtest.fork" value="yes" />

--- a/codegenerator/src/main/resources/build.xml.template
+++ b/codegenerator/src/main/resources/build.xml.template
@@ -17,7 +17,7 @@
   <property name="junit.fork" value="yes" />
   <property name="junit.timeout" value="60000" />
   <property name="junit.jvm" value="" />
-  <property name="junit.jvm.options" value="-Xms128m -Xmx512m -XX:MaxPermSize=256m" />
+  <property name="junit.jvm.options" value="-Xms128m -Xmx512m" />
   <property name="junit.batchtest.haltonerror" value="no" />
   <property name="junit.batchtest.haltonfailure" value="no" />
   <property name="junit.batchtest.fork" value="yes" />

--- a/doc/developerguide/en-US/modules/building.xml
+++ b/doc/developerguide/en-US/modules/building.xml
@@ -52,7 +52,7 @@ export PATH
       <para>You may need to set the memory settings for the Apache Ant process like</para>
 
       <programlisting>
-ANT_OPTS="$ANT_OPTS -Xms128m -Xmx512m -XX:MaxPermSize=256m"
+ANT_OPTS="$ANT_OPTS -Xms128m -Xmx512m"
 export ANT_OPTS
       </programlisting>
     </section>


### PR DESCRIPTION
Based on RadHat JDK 17 effort, it was suggested to get rid of -XX:MaxPermSize=256m jvm arguments, because it's useless since JDK8.