### PR TITLE
Fix typo in exception message

### DIFF
--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/extensions/mysql/MySQLReauthPlugin.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/extensions/mysql/MySQLReauthPlugin.java
@@ -82,7 +82,7 @@ public class MySQLReauthPlugin implements ReauthPlugin
          }
          catch (Throwable t) 
          {
-            throw new SQLException("Cannot resolve com.mysq.jdbc.Connection", t);
+            throw new SQLException("Cannot resolve com.mysql.jdbc.Connection", t);
          }
       }
 
@@ -92,7 +92,7 @@ public class MySQLReauthPlugin implements ReauthPlugin
       }
       catch (Throwable t)
       {
-         throw new SQLException("Cannot resolve com.mysq.jdbc.Connection changeUser method", t);
+         throw new SQLException("Cannot resolve com.mysql.jdbc.Connection changeUser method", t);
       }
    }
 


### PR DESCRIPTION
There is a typo in exception message, making debuging harder. This MR fixes it.