### PR TITLE
[JBJCA-1461] Flush connection's prepared statement cache on endReques…

### DIFF
--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/BaseWrapperManagedConnection.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/BaseWrapperManagedConnection.java
@@ -1290,6 +1290,15 @@ public abstract class BaseWrapperManagedConnection implements NotifyingManagedCo
       }
       if (mh.isPresent())
          invokeNotifyMethod(mh.get(), "endRequest");
+      flushPreparedStatementCache();
+   }
+
+   private void flushPreparedStatementCache()
+   {
+      if(psCache != null)
+      {
+         psCache.flush();
+      }
    }
 
    private Optional<MethodHandle> lookupNotifyMethod(String methodName)

--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/PreparedStatementCache.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/PreparedStatementCache.java
@@ -234,6 +234,11 @@ public class PreparedStatementCache implements CacheListener<CachedPreparedState
       }
    }
 
+   void flush()
+   {
+      cache.flush();
+   }
+
    /**
     * {@inheritDoc}
     */


### PR DESCRIPTION
…t notification

Although, as discussed in EAPSUP-671, we recommend to turn prepared statement cache off for SQL driver, I'm proposing this fix to avoid situations as in WFLY-15493. 

@bmaxwell what do you think? Is this fix reasonable? Would it colide with Oracle's EAP7-168 progress?