### PR TITLE
[JBJCA-1470] typo at toString method in SemaphoreConcurrentLinkedDequeManagedConnectionPool class

### DIFF
--- a/core/impl/src/main/java/org/jboss/jca/core/connectionmanager/pool/mcp/ManagedConnectionPoolFactory.java
+++ b/core/impl/src/main/java/org/jboss/jca/core/connectionmanager/pool/mcp/ManagedConnectionPoolFactory.java
@@ -55,7 +55,7 @@ public class ManagedConnectionPoolFactory
    /** Deprecated implementations */
    private static final String[] DEPRECATED_IMPLEMENTATIONS = new String[] {
       "org.jboss.jca.core.connectionmanager.pool.mcp.ArrayBlockingQueueManagedConnectionPool",
-      "org.jboss.jca.core.connectionmanager.pool.mcp.SemaphoreConcurrentLinkedQueueManagedConnectionPool"
+      "org.jboss.jca.core.connectionmanager.pool.mcp.SemaphoreConcurrentLinkedDequeManagedConnectionPool"
    };
    
    /** Default class definition */

--- a/core/impl/src/main/java/org/jboss/jca/core/connectionmanager/pool/mcp/SemaphoreConcurrentLinkedDequeManagedConnectionPool.java
+++ b/core/impl/src/main/java/org/jboss/jca/core/connectionmanager/pool/mcp/SemaphoreConcurrentLinkedDequeManagedConnectionPool.java
@@ -1691,7 +1691,7 @@ public class SemaphoreConcurrentLinkedDequeManagedConnectionPool implements Mana
    {
       StringBuilder sb = new StringBuilder();
 
-      sb.append("SemaphoreConcurrentLinkedQueueManagedConnectionPool@");
+      sb.append("SemaphoreConcurrentLinkedDequeManagedConnectionPool@");
       sb.append(Integer.toHexString(System.identityHashCode(this)));
       sb.append("[pool=").append(pool.getName());
       sb.append("]");

--- a/doc/developerguide/en-US/modules/pool.xml
+++ b/doc/developerguide/en-US/modules/pool.xml
@@ -297,8 +297,8 @@
       <para>
         There are three different implementations of the <code>ManagedConnectionPool</code> interface. <code>SemaphoreArrayListManagedConnectionPool</code>
         which uses an <code>ArrayList</code> to hold the <code>ConnectionListener</code>s.
-        <code>SemaphoreConcurrentLinkedQueueManagedConnectionPool</code> which uses a <code>ConcurrentLinkedQueue</code>
-        to hold the <code>ConnectionListener</code>s. <code>SemaphoreConcurrentLinkedQueueManagedConnectionPool</code> also uses a <code>ConcurrentHashMap</code>
+        <code>SemaphoreConcurrentLinkedDequeManagedConnectionPool</code> which uses a <code>ConcurrentLinkedQueue</code>
+        to hold the <code>ConnectionListener</code>s. <code>SemaphoreConcurrentLinkedDequeManagedConnectionPool</code> also uses a <code>ConcurrentHashMap</code>
         to keep track of the internal status of each of the <code>ConnectionListener</code>s.
         Last, a <code>LeakDumperManagedConnectionPool</code> which extends <code>SemaphoreArrayListManagedConnectionPool</code>, but reports any leaks upon
         shutdown.

--- a/tools/findbugs/filter.xml
+++ b/tools/findbugs/filter.xml
@@ -338,7 +338,7 @@
     <Bug code="DLS,NP,BC,RCN"/>
   </Match>
   <Match>
-    <Class name="org.jboss.jca.core.connectionmanager.pool.mcp.SemaphoreConcurrentLinkedQueueManagedConnectionPool"/>
+    <Class name="org.jboss.jca.core.connectionmanager.pool.mcp.SemaphoreConcurrentLinkedDequeManagedConnectionPool"/>
     <Bug code="BC,JLM,RCN,REC"/>
   </Match>
   <Match>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBJCA-1470