### PR TITLE
[JBCA-1484] XAManagedConnection: fix argument type of broadcastConnec…

### DIFF
--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/xa/XAManagedConnection.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/xa/XAManagedConnection.java
@@ -198,7 +198,8 @@ public class XAManagedConnection extends BaseWrapperManagedConnection implements
    /**
     * {@inheritDoc}
     */
-   protected void broadcastConnectionError(SQLException e)
+   @Override
+   protected void broadcastConnectionError(Throwable e)
    {
       if (failedToEndXids == null) {
          this.failedToEndXids = new HashSet<>();


### PR DESCRIPTION
Fix the argument type of XAManagedConnection.broadcastConnectionError() to resolve JBCA-1484 (#790).

In the current implementation, the broadcastConnectionError() does not override the super method, so it is not called from XAManagedConnection.end().