### PR TITLE
[JBJCA-1485] Bump wildfly-transaction-client to 3.0.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <version.org.mockito>2.18.0</version.org.mockito>
         <version.org.picketbox>5.0.3.Final</version.org.picketbox>
         <version.org.wildfly.common>1.3.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.transaction.client>3.0.0.Final</version.org.wildfly.transaction.client>
+        <version.org.wildfly.transaction.client>3.0.3.Final</version.org.wildfly.transaction.client>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Bumping the library to avoid [CVE-2022-0853](https://devhub.checkmarx.com/cve-details/CVE-2022-0853/)