### PR TITLE
eliminate spotbugs Inconsistent synchronization in org.jboss.jca.adapters.jdbc classes

### DIFF
--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/BaseWrapperManagedConnection.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/BaseWrapperManagedConnection.java
@@ -101,7 +101,7 @@ public abstract class BaseWrapperManagedConnection implements NotifyingManagedCo
    protected final Object stateLock = new Object();
 
    /** Is inside a managed transaction */
-   protected boolean inManagedTransaction = false;
+   protected volatile boolean inManagedTransaction = false;
 
    /** Is inside a local transaction */
    protected AtomicBoolean inLocalTransaction = new AtomicBoolean(false);
@@ -115,7 +115,7 @@ public abstract class BaseWrapperManagedConnection implements NotifyingManagedCo
    protected static boolean setAutoCommitOnCleanup = true;
 
    /** Underlying auto-commit */
-   protected boolean underlyingAutoCommit = true;
+   protected volatile boolean underlyingAutoCommit = true;
 
    // See JBAS-5678
    private boolean shouldRollbackOnDestroy = false;

--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/BaseWrapperManagedConnectionFactory.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/BaseWrapperManagedConnectionFactory.java
@@ -246,10 +246,10 @@ public abstract class BaseWrapperManagedConnectionFactory
    private Boolean reauthEnabled = Boolean.FALSE;
 
    /** Reauth plugin class name */
-   private String reauthPluginClassName;
+   private volatile String reauthPluginClassName;
 
    /** Reauth plugin properties - format: [key|value](,key|value)+ */
-   private String reauthPluginProperties;
+   private volatile String reauthPluginProperties;
 
    /** Reauth plugin */
    private ReauthPlugin reauthPlugin;
@@ -263,13 +263,13 @@ public abstract class BaseWrapperManagedConnectionFactory
    private Boolean jta = Boolean.TRUE;
 
    /** Connection listener plugin class name */
-   private String connectionListenerClassName;
+   private volatile String connectionListenerClassName;
 
    /** Connection listener plugin properties - format: [key|value](,key|value)+ */
-   private String connectionListenerProperties;
+   private volatile String connectionListenerProperties;
 
    /** Connection listener plugin */
-   private ConnectionListener connectionListenerPlugin;
+   private volatile ConnectionListener connectionListenerPlugin;
 
    private ClassLoader originalTCCL;
 

--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/local/LocalManagedConnectionFactory.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/local/LocalManagedConnectionFactory.java
@@ -67,7 +67,7 @@ public class LocalManagedConnectionFactory extends BaseWrapperManagedConnectionF
 
    private String dataSourceClass;
 
-   private transient Driver driver;
+   private transient volatile Driver driver;
 
    private transient DataSource dataSource;
 


### PR DESCRIPTION
Before change, I ran:
spotbugs-4.8.3/bin/spotbugs -textui -project /home/smarlow/tools/spotbugs-4.8.3/ironjacamar.xml  &> spotbugsoutput2.txt

After change, I ran:
spotbugs-4.8.3/bin/spotbugs -textui -project /home/smarlow/tools/spotbugs-4.8.3/ironjacamar.xml  &> spotbugsoutput3.txt

Output of `grep "M M IS: Inconsistent synchronization" spotbugsoutput2.txt| grep org.jboss.jca.adapters.jdbc` shows:

> grep "M M IS: Inconsistent synchronization" spotbugsoutput2.txt| grep org.jboss.jca.adapters.jdbc
> M M IS: Inconsistent synchronization of org.jboss.jca.adapters.jdbc.BaseWrapperManagedConnectionFactory.connectionListenerClassName; locked 55% of time  Unsynchronized access at BaseWrapperManagedConnectionFactory.java:[line 861]
> M M IS: Inconsistent synchronization of org.jboss.jca.adapters.jdbc.BaseWrapperManagedConnection.inManagedTransaction; locked 66% of time  Unsynchronized access at BaseWrapperManagedConnection.java:[line 900]
> M M IS: Inconsistent synchronization of org.jboss.jca.adapters.jdbc.local.LocalManagedConnectionFactory.driver; locked 55% of time  Unsynchronized access at LocalManagedConnectionFactory.java:[line 172]
> M M IS: Inconsistent synchronization of org.jboss.jca.adapters.jdbc.BaseWrapperManagedConnection.underlyingAutoCommit; locked 50% of time  Unsynchronized access at BaseWrapperManagedConnection.java:[line 904]
> M M IS: Inconsistent synchronization of org.jboss.jca.adapters.jdbc.BaseWrapperManagedConnectionFactory.connectionListenerProperties; locked 50% of time  Unsynchronized access at BaseWrapperManagedConnectionFactory.java:[line 880]
> M M IS: Inconsistent synchronization of org.jboss.jca.adapters.jdbc.BaseWrapperManagedConnectionFactory.connectionListenerPlugin; locked 57% of time  Unsynchronized access at BaseWrapperManagedConnectionFactory.java:[line 992]
> M M IS: Inconsistent synchronization of org.jboss.jca.adapters.jdbc.BaseWrapperManagedConnectionFactory.reauthPluginClassName; locked 71% of time  Unsynchronized access at BaseWrapperManagedConnectionFactory.java:[line 713]
> M M IS: Inconsistent synchronization of org.jboss.jca.adapters.jdbc.BaseWrapperManagedConnectionFactory.reauthPluginProperties; locked 50% of time  Unsynchronized access at BaseWrapperManagedConnectionFactory.java:[line 742]


Output of `grep "M M IS: Inconsistent synchronization" spotbugsoutput3.txt| grep org.jboss.jca.adapters.jdbc` is empty.



