### PR TITLE
[JBJCA-1483] TxConnectionListener#tidyup: make sure that localTransac…

### DIFF
--- a/core/impl/src/main/java/org/jboss/jca/core/connectionmanager/listener/TxConnectionListener.java
+++ b/core/impl/src/main/java/org/jboss/jca/core/connectionmanager/listener/TxConnectionListener.java
@@ -732,6 +732,7 @@ public class TxConnectionListener extends AbstractConnectionListener
          else
          {
             local.rollback();
+            localTransaction.set(false);
             log.debugf("Unfinished local transaction was rolled back.%s", this);
          }
       }


### PR DESCRIPTION
…tion field is set to false after the operation

Issue: https://issues.redhat.com/browse/JBEAP-27126
Upstream issue: https://issues.redhat.com/browse/JBJCA-1483
Upstream PR: https://github.com/ironjacamar/ironjacamar/commit/6eecab06d2581d90a212dc46d427a07f6b9e8fe7