### PR TITLE
Bump to JUnit 4.13.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <version.jakarta.transaction.jakarta-transaction-api>2.0.1</version.jakarta.transaction.jakarta-transaction-api>
         <version.jakarta.validation.jakarta-validation-api>3.0.2</version.jakarta.validation.jakarta-validation-api>
         <version.jakarta.websocket.jakarta-websocket-api>2.1.0.jbossorg-1</version.jakarta.websocket.jakarta-websocket-api>
-        <version.junit>4.12</version.junit>
+        <version.junit>4.13.2</version.junit>
         <version.org.apache.ant>1.10.14</version.org.apache.ant>
         <version.org.apache.maven>3.9.9</version.org.apache.maven>
         <version.org.apache.maven.plugin.tools>3.14.0</version.org.apache.maven.plugin.tools>


### PR DESCRIPTION
It gets rid of the CVE-2020-15250 warning
