### PR TITLE
[JBJCA-1500] AbstractConnectionListener#isTimedOut can return false for timed out connections

### DIFF
--- a/core/impl/src/main/java/org/jboss/jca/core/connectionmanager/listener/AbstractConnectionListener.java
+++ b/core/impl/src/main/java/org/jboss/jca/core/connectionmanager/listener/AbstractConnectionListener.java
@@ -284,7 +284,7 @@ public abstract class AbstractConnectionListener implements ConnectionListener, 
     */   
    public boolean isTimedOut(long timeout)
    {      
-      return (lastCheckedOut < lastReturned) && (lastReturned < timeout);
+      return (lastCheckedOut <= lastReturned) && (lastReturned < timeout);
    }
 
    /**


### PR DESCRIPTION
ISSUE: https://issues.redhat.com/browse/JBJCA-1500