### PR TITLE
fix the enlist synchronized process to follow the same logic as the s…

### DIFF
--- a/core/impl/src/main/java/org/jboss/jca/core/connectionmanager/listener/TxConnectionListener.java
+++ b/core/impl/src/main/java/org/jboss/jca/core/connectionmanager/listener/TxConnectionListener.java
@@ -987,23 +987,17 @@ public class TxConnectionListener extends AbstractConnectionListener
          try
          {
             XAResource resource = getXAResource();
-            if (!(enlistResult = currentTx.enlistResource(resource)))
-            {
-               if (Tracer.isEnabled())
-                  Tracer.enlistConnectionListener(getPool() != null ? getPool().getName() : null, 
-                                                  getManagedConnectionPool(),
-                                                  TxConnectionListener.this, currentTx.toString(), false,
-                                                  !TxConnectionListener.this.isTrackByTx());
+            enlistResult = currentTx.enlistResource(resource);
+            if (Tracer.isEnabled())
+               Tracer.enlistConnectionListener(getPool() != null ? getPool().getName() : null,
+                                               getManagedConnectionPool(),
+                                               TxConnectionListener.this, currentTx.toString(), enlistResult,
+                                               !TxConnectionListener.this.isTrackByTx());
+
+            if (!enlistResult && recordEnlist){
                enlistError = failedToEnlist;
             }
-            else
-            {
-               if (Tracer.isEnabled())
-                  Tracer.enlistConnectionListener(getPool() != null ? getPool().getName() : null,
-                                                  getManagedConnectionPool(),
-                                                  TxConnectionListener.this, currentTx.toString(), true,
-                                                  !TxConnectionListener.this.isTrackByTx());
-            }
+
          }
          catch (Throwable t)
          {


### PR DESCRIPTION
**Summary**
We are using version 1.5.3 of ironjacamar and are experiencing an error similar to the one described in the following issue:

Red Hat Solution
Since it has been addressed in JBJCA-1413, we compared the source code of version 1.5.x and noticed that the behavior of the enlist() method in core/src/main/java/org/jboss/jca/core/connectionmanager/listener/TxConnectionListener.java seems to have changed slightly. We have considered a solution.

**Details**

The fix applied in ironjacamar 1.4 ([JBJCA-1413,](https://issues.redhat.com/browse/JBJCA-1413)) appears to have changed the behavior of the enlist() method as a result of refactoring in ironjacamar 1.5.x.

- 1.4 version:

Pull Request 708
In the enlist() method, if recordEnlist == false, enlistError = null is set.
Within synchronized (this), it returns true.
Since enlistError is set to null, it does not result in an error in checkEnlisted().

- 1.5.x version:

Commit 9be57601cfe9feadafc907cfd99fdef88ce015d0
In the enlist() method, regardless of the value of recordEnlist, enlistResult is returned.
Additionally, within synchronized (this), only enlistResult is evaluated.
Since recordEnlist is not evaluated to set enlistError, we believe it results in an error in checkEnlisted().

Please confirm.