### PR TITLE
[JBJCA-1493] fix postRun check in WorkManagerStartWorkTestCase#testStartWorkFullSpecWithImmediateStartTimeout

### DIFF
--- a/core/tests/src/test/java/org/jboss/jca/core/workmanager/spec/chapter10/api/WorkManagerStartWorkTestCase.java
+++ b/core/tests/src/test/java/org/jboss/jca/core/workmanager/spec/chapter10/api/WorkManagerStartWorkTestCase.java
@@ -188,8 +188,8 @@ public class WorkManagerStartWorkTestCase
       start.countDown();
 
       workManager.startWork(work, WorkManager.IMMEDIATE, null, null);
-
-      assertFalse(work.hasPostRun());
+      done.await();
+      assertTrue(work.hasPostRun());
    }
 
    /**


### PR DESCRIPTION
https://issues.redhat.com/browse/JBJCA-1493

reverts changes from https://github.com/ironjacamar/ironjacamar/commit/eee47585dc0d2c58dc9124ad4b750f3393f6a81d#diff-3ef3abd32ff8585ea77554478f5974550b24ed2f6e21586db60d2399d7676ea8R192