### PR TITLE
[JBJCA-1518] Fix MBean name registration for type PoolConfiguration

### DIFF
--- a/deployers/fungal/src/main/java/org/jboss/jca/deployers/fungal/DsXmlDeployer.java
+++ b/deployers/fungal/src/main/java/org/jboss/jca/deployers/fungal/DsXmlDeployer.java
@@ -539,7 +539,7 @@ public class DsXmlDeployer extends AbstractDsDeployer implements Deployer
 
                if (mgtDs.getPoolConfiguration() != null)
                {
-                  String dsPCName = baseName + ",type=PoolConfigutation";
+                  String dsPCName = baseName + ",type=PoolConfiguration";
 
                   DynamicMBean dsPCDMB = JMX.createMBean(mgtDs.getPoolConfiguration(), "Pool configuration");
                   ObjectName dsPCON = new ObjectName(dsPCName);


### PR DESCRIPTION
Test using :

mBeanServer. queryNames( new ObjectName ("iron.jacamar:type=PoolConfiguration"))