### PR TITLE
JDBC driver override credentials even when user/password are being provided.

### DIFF
--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/local/LocalManagedConnectionFactory.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/local/LocalManagedConnectionFactory.java
@@ -42,8 +42,10 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.stream.Collectors;
 
 import static java.security.AccessController.doPrivileged;
+import static org.jboss.jca.adapters.jdbc.util.CredentialsPropertyOverrideUtil.overrideCredentials;
 
 import jakarta.resource.ResourceException;
 import jakarta.resource.spi.ConnectionManager;
@@ -293,6 +295,7 @@ public class LocalManagedConnectionFactory extends BaseWrapperManagedConnectionF
                                                                final Properties copy)
       throws ResourceException
    {
+
       if (driverClass != null && driver == null)
       {
          try
@@ -332,7 +335,7 @@ public class LocalManagedConnectionFactory extends BaseWrapperManagedConnectionF
             SecurityActions.setThreadContextClassLoader(SecurityActions.getClassLoader(d.getClass()));
             try
             {
-               con = d.connect(url, copy);
+               con = d.connect(url, overrideCredentials(copy));
                if (con == null)
                   throw new ResourceException(bundle.wrongDriverClass(d.getClass().getName(), url));
             }

--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/util/CredentialsPropertyOverrideUtil.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/util/CredentialsPropertyOverrideUtil.java
@@ -1,0 +1,53 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2026, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.jca.adapters.jdbc.util;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+public class CredentialsPropertyOverrideUtil {
+
+    /**
+     * Some JDBC drivers don't allow to override the credentials connection configuration causing getConnection(user,pass) not working as expected
+     * and using the default credentials. This allows to bypass this situation removing the default configuration and providing user and password.
+     * https://issues.redhat.com/browse/JBJCA-1533
+     * @param connectionProperties current JDBC configuration properties
+     * @return Properties cloned if user and password are provided and the property is being supplied
+     */
+    public static Properties overrideCredentials(Properties connectionProperties) {
+        boolean override = connectionProperties.getProperty("user") != null && connectionProperties.getProperty("password") != null;
+        List<String> credentialsOverrideProperty = List.of(connectionProperties.getProperty("org.ironjacamar.connection.credentials.override", "").split(","));
+        if (override && !credentialsOverrideProperty.isEmpty()) {
+            Properties overrideProperties = new Properties();
+            for (String key : connectionProperties.keySet().stream().map(String.class::cast).collect(Collectors.toList())) {
+                if (credentialsOverrideProperty.contains(key)) {
+                    continue;
+                }
+                overrideProperties.setProperty(key, connectionProperties.getProperty(key));
+            }
+            return overrideProperties;
+        } else {
+            return connectionProperties;
+        }
+    }
+}

--- a/adapters/src/main/java/org/jboss/jca/adapters/jdbc/xa/XAManagedConnectionFactory.java
+++ b/adapters/src/main/java/org/jboss/jca/adapters/jdbc/xa/XAManagedConnectionFactory.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import java.util.StringTokenizer;
 
 import static java.security.AccessController.doPrivileged;
+import static org.jboss.jca.adapters.jdbc.util.CredentialsPropertyOverrideUtil.overrideCredentials;
 
 import jakarta.resource.ResourceException;
 import jakarta.resource.spi.ConnectionRequestInfo;
@@ -543,7 +544,8 @@ public class XAManagedConnectionFactory extends BaseWrapperManagedConnectionFact
     */
    protected ManagedConnection newXAManagedConnection(Properties props, XAConnection xaConnection) throws SQLException
    {
-      return new XAManagedConnection(this, xaConnection, props, transactionIsolation, preparedStatementCacheSize);
+      
+      return new XAManagedConnection(this, xaConnection, overrideCredentials(props), transactionIsolation, preparedStatementCacheSize);
    }
 
    /**


### PR DESCRIPTION
Some jdbc drivers an combinations of data sources configuration can lead to ignore user/password credentials when getting a connection.