### PR TITLE
Replace `LinkedList` with `ArrayList` where appropriate

### DIFF
--- a/as/src/main/java/org/jboss/jca/as/rarinfo/Main.java
+++ b/as/src/main/java/org/jboss/jca/as/rarinfo/Main.java
@@ -73,7 +73,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1358,7 +1358,7 @@ public class Main
     */
    private static URL[] getUrls(File directory) throws MalformedURLException, IOException
    {
-      List<URL> list = new LinkedList<URL>();
+      List<URL> list = new ArrayList<URL>();
 
       if (directory.exists() && directory.isDirectory())
       {

--- a/as/src/main/java/org/jboss/jca/as/rarinfo/Main.java
+++ b/as/src/main/java/org/jboss/jca/as/rarinfo/Main.java
@@ -73,7 +73,6 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1178,7 +1177,7 @@ public class Main
                if (jar.endsWith(".jar"))
                   listUrl.add(new File(jar).toURI().toURL());
             }
-            allurls = listUrl.toArray(new URL[listUrl.size()]);
+            allurls = listUrl.toArray(new URL[0]);
          }
          else
             allurls = urls;
@@ -1388,7 +1387,7 @@ public class Main
             }
          }
       }
-      return list.toArray(new URL[list.size()]);
+      return list.toArray(new URL[0]);
    }
 
    /**

--- a/core/impl/src/main/java/org/jboss/jca/core/connectionmanager/ccm/CachedConnectionManagerImpl.java
+++ b/core/impl/src/main/java/org/jboss/jca/core/connectionmanager/ccm/CachedConnectionManagerImpl.java
@@ -39,7 +39,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -93,8 +94,8 @@ public class CachedConnectionManagerImpl implements CachedConnectionManager
     * behavior of it getting hooked up to an appropriate
     * ManagedConnection on each method invocation.
     */
-   private final ThreadLocal<LinkedList<KeyConnectionAssociation>> currentObjects =
-      new ThreadLocal<LinkedList<KeyConnectionAssociation>>();
+   private final ThreadLocal<List<KeyConnectionAssociation>> currentObjects =
+      new ThreadLocal<List<KeyConnectionAssociation>>();
 
    /**
     * The variable <code>objectToConnectionManagerMap</code> holds the
@@ -257,11 +258,11 @@ public class CachedConnectionManagerImpl implements CachedConnectionManager
     */
    private KeyConnectionAssociation peekMetaAwareObject()
    {
-      LinkedList<KeyConnectionAssociation> stack = currentObjects.get();
+      List<KeyConnectionAssociation> stack = currentObjects.get();
 
       if (stack != null && !stack.isEmpty())
       {
-         return stack.getLast();
+         return stack.get(stack.size() - 1);
       }
 
       return null;
@@ -274,8 +275,8 @@ public class CachedConnectionManagerImpl implements CachedConnectionManager
    @SuppressWarnings("unchecked")
    public void popMetaAwareObject(Set unsharableResources) throws ResourceException
    {
-      LinkedList<KeyConnectionAssociation> stack = currentObjects.get();
-      KeyConnectionAssociation oldKey = stack.removeLast();
+      List<KeyConnectionAssociation> stack = currentObjects.get();
+      KeyConnectionAssociation oldKey = stack.remove(stack.size() - 1);
 
       log.tracef("popped object: %s", oldKey);
 
@@ -414,14 +415,14 @@ public class CachedConnectionManagerImpl implements CachedConnectionManager
    @SuppressWarnings("unchecked")
    public void pushMetaAwareObject(final Object rawKey, Set unsharableResources) throws ResourceException
    {
-      LinkedList<KeyConnectionAssociation> stack = currentObjects.get();
+      List<KeyConnectionAssociation> stack = currentObjects.get();
       KeyConnectionAssociation key = new KeyConnectionAssociation(rawKey);
 
       if (stack == null)
       {
          log.tracef("new stack for key: %s", key);
 
-         stack = new LinkedList<KeyConnectionAssociation>();
+         stack = new ArrayList<KeyConnectionAssociation>();
          currentObjects.set(stack);
       }
       else if (stack.isEmpty())
@@ -430,14 +431,14 @@ public class CachedConnectionManagerImpl implements CachedConnectionManager
       }
       else
       {
-         log.tracef("old stack for key: %s", stack.getLast());
+         log.tracef("old stack for key: %s", stack.get(stack.size() - 1));
          log.tracef("new stack for key: %s", key);
       }
 
       if (Tracer.isEnabled())
          Tracer.pushCCMContext(key.toString(), new Throwable("CALLSTACK"));
 
-      stack.addLast(key);
+      stack.add(key);
    }
 
    /**
@@ -712,7 +713,7 @@ public class CachedConnectionManagerImpl implements CachedConnectionManager
     *
     * @return the currentObjects.
     */
-   final ThreadLocal<LinkedList<KeyConnectionAssociation>> getCurrentObjects()
+   final ThreadLocal<List<KeyConnectionAssociation>> getCurrentObjects()
    {
       return currentObjects;
    }

--- a/core/impl/src/main/java/org/jboss/jca/core/connectionmanager/pool/AbstractPool.java
+++ b/core/impl/src/main/java/org/jboss/jca/core/connectionmanager/pool/AbstractPool.java
@@ -1163,7 +1163,7 @@ public abstract class AbstractPool implements Pool
          }
       }
 
-      return result.toArray(new String[result.size()]);
+      return result.toArray(new String[0]);
    }
 
    /**

--- a/core/impl/src/main/java/org/jboss/jca/core/rar/EndpointImpl.java
+++ b/core/impl/src/main/java/org/jboss/jca/core/rar/EndpointImpl.java
@@ -177,7 +177,7 @@ public class EndpointImpl implements Endpoint
             if (groups.isEmpty())
                groups.add(Default.class);
 
-            Class[] vargs = groups.toArray(new Class[groups.size()]);
+            Class[] vargs = groups.toArray(new Class[0]);
 
             Set errors = validator.validate(spec, vargs);
 

--- a/core/impl/src/main/java/org/jboss/jca/core/security/AbstractCallback.java
+++ b/core/impl/src/main/java/org/jboss/jca/core/security/AbstractCallback.java
@@ -98,7 +98,7 @@ public abstract class AbstractCallback implements Callback
                }
 
                l.add(new GroupPrincipalCallback(groupPrincipalCallback.getSubject(),
-                     gs.toArray(new String[gs.size()])));
+                     gs.toArray(new String[0])));
             }
             else
             {
@@ -111,6 +111,6 @@ public abstract class AbstractCallback implements Callback
          }
       }
 
-      return l.toArray(new javax.security.auth.callback.Callback[l.size()]);
+      return l.toArray(new javax.security.auth.callback.Callback[0]);
    }
 }

--- a/core/impl/src/main/java/org/jboss/jca/core/security/DefaultCallback.java
+++ b/core/impl/src/main/java/org/jboss/jca/core/security/DefaultCallback.java
@@ -298,7 +298,7 @@ public class DefaultCallback extends AbstractCallback implements Callback
                         {
                            groups.add(st.nextToken().trim());
                         }
-                        defaultGroups = groups.toArray(new String[groups.size()]);
+                        defaultGroups = groups.toArray(new String[0]);
                      }
                   }
                   else if (key.startsWith("map.user"))

--- a/core/impl/src/main/java/org/jboss/jca/core/security/picketbox/PicketBoxSecurityContext.java
+++ b/core/impl/src/main/java/org/jboss/jca/core/security/picketbox/PicketBoxSecurityContext.java
@@ -78,7 +78,7 @@ public class PicketBoxSecurityContext implements SecurityContext
          {
             l.add(role.getRoleName());
          }
-         roles = l.toArray(new String[l.size()]);
+         roles = l.toArray(new String[0]);
       }
 
       return roles;

--- a/core/impl/src/main/java/org/jboss/jca/core/workmanager/ClassBundleFactory.java
+++ b/core/impl/src/main/java/org/jboss/jca/core/workmanager/ClassBundleFactory.java
@@ -201,6 +201,6 @@ public class ClassBundleFactory
          c = c.getSuperclass();
       }
 
-      return result.toArray(new Class<?>[result.size()]);
+      return result.toArray(new Class<?>[0]);
    }
 }

--- a/core/tests/src/test/java/org/jboss/jca/core/workmanager/unit/WorkManagerSecurityTestCase.java
+++ b/core/tests/src/test/java/org/jboss/jca/core/workmanager/unit/WorkManagerSecurityTestCase.java
@@ -356,7 +356,7 @@ public class WorkManagerSecurityTestCase
             List<javax.security.auth.callback.Callback> cbs = new ArrayList<javax.security.auth.callback.Callback>();
             cbs.add(new CallerPrincipalCallback(executionSubject, new SimplePrincipal("eis")));
             cbs.add(new GroupPrincipalCallback(executionSubject, new String[] {"eis"}));
-            handler.handle(cbs.toArray(new javax.security.auth.callback.Callback[cbs.size()]));
+            handler.handle(cbs.toArray(new javax.security.auth.callback.Callback[0]));
          }
          catch (Throwable t)
          {

--- a/deployers/common/src/main/java/org/jboss/jca/deployers/common/AbstractDsDeployer.java
+++ b/deployers/common/src/main/java/org/jboss/jca/deployers/common/AbstractDsDeployer.java
@@ -407,13 +407,13 @@ public abstract class AbstractDsDeployer
          return new CommonDeployment(url, deploymentName, true,
                                      resourceAdapter, resourceAdapterKey, 
                                      bootstrapContextIdentifier,
-                                     cfs.toArray(new Object[cfs.size()]),
-                                     jndis.toArray(new String[jndis.size()]),
-                                     cms.toArray(new ConnectionManager[cms.size()]),
+                                     cfs.toArray(new Object[0]),
+                                     jndis.toArray(new String[0]),
+                                     cms.toArray(new ConnectionManager[0]),
                                      null, null,
-                                     recoveryModules.toArray(new XAResourceRecovery[recoveryModules.size()]),
+                                     recoveryModules.toArray(new XAResourceRecovery[0]),
                                      null,
-                                     mgts.toArray(new org.jboss.jca.core.api.management.DataSource[mgts.size()]),
+                                     mgts.toArray(new org.jboss.jca.core.api.management.DataSource[0]),
                                      parentClassLoader, log);
       }
       catch (DeployException de)

--- a/deployers/common/src/main/java/org/jboss/jca/deployers/common/AbstractResourceAdapterDeployer.java
+++ b/deployers/common/src/main/java/org/jboss/jca/deployers/common/AbstractResourceAdapterDeployer.java
@@ -963,7 +963,7 @@ public abstract class AbstractResourceAdapterDeployer
                                        interfaces.add(jakarta.resource.Referenceable.class);
                                        
                                        ao = Proxy.newProxyInstance(SecurityActions.getClassLoader(ao.getClass()),
-                                                                   interfaces.toArray(new Class<?>[interfaces.size()]),
+                                                                   interfaces.toArray(new Class<?>[0]),
                                                                    dih);
                                     }
 
@@ -2031,17 +2031,17 @@ public abstract class AbstractResourceAdapterDeployer
             }
          }
 
-         Object[] cfObjs = cfs.size() > 0 ? cfs.toArray(new Object[cfs.size()]) : null;
-         String[] cfJndis = cfJndiNames.size() > 0 ? cfJndiNames.toArray(new String[cfJndiNames.size()]) : null;
-         ConnectionManager[] cfCM = cfCMs.size() > 0 ? cfCMs.toArray(new ConnectionManager[cfCMs.size()]) : null;
-         Object[] aoObjs = aos.size() > 0 ? aos.toArray(new Object[aos.size()]) : null;
-         String[] aoJndis = aoJndiNames.size() > 0 ? aoJndiNames.toArray(new String[aoJndiNames.size()]) : null;
+         Object[] cfObjs = cfs.size() > 0 ? cfs.toArray(new Object[0]) : null;
+         String[] cfJndis = cfJndiNames.size() > 0 ? cfJndiNames.toArray(new String[0]) : null;
+         ConnectionManager[] cfCM = cfCMs.size() > 0 ? cfCMs.toArray(new ConnectionManager[0]) : null;
+         Object[] aoObjs = aos.size() > 0 ? aos.toArray(new Object[0]) : null;
+         String[] aoJndis = aoJndiNames.size() > 0 ? aoJndiNames.toArray(new String[0]) : null;
          
          return new CommonDeployment(url, deploymentName, activateDeployment,
                                      resourceAdapter, resourceAdapterKey, bootstrapContextIdentifier,
                                      cfObjs, cfJndis, cfCM,
                                      aoObjs, aoJndis,
-                                     recoveryModules.toArray(new XAResourceRecovery[recoveryModules.size()]),
+                                     recoveryModules.toArray(new XAResourceRecovery[0]),
                                      mgtConnector, null, cl, log);
 
       }
@@ -2227,7 +2227,7 @@ public abstract class AbstractResourceAdapterDeployer
          String d = ws.getDomain();
          String dp = ws.getDefaultPrincipal();
          String[] dgs = ws.getDefaultGroups() != null ? 
-            ws.getDefaultGroups().toArray(new String[ws.getDefaultGroups().size()]) : null;
+            ws.getDefaultGroups().toArray(new String[0]) : null;
          Map<String, String> ps = ws.getUserMappings();
          Map<String, String> gs = ws.getGroupMappings();
 

--- a/deployers/common/src/main/java/org/jboss/jca/deployers/common/BeanValidation.java
+++ b/deployers/common/src/main/java/org/jboss/jca/deployers/common/BeanValidation.java
@@ -100,7 +100,7 @@ public class BeanValidation
       }
       else
       {
-         Class[] vargs = groupsClasses.toArray(new Class[groupsClasses.size()]);
+         Class[] vargs = groupsClasses.toArray(new Class[0]);
 
          if (log.isTraceEnabled())
             log.tracef("Validating: %s against groups %s", object, Arrays.toString(vargs));

--- a/deployers/fungal/src/main/java/org/jboss/jca/deployers/fungal/AbstractFungalRADeployer.java
+++ b/deployers/fungal/src/main/java/org/jboss/jca/deployers/fungal/AbstractFungalRADeployer.java
@@ -279,7 +279,7 @@ public abstract class AbstractFungalRADeployer extends AbstractResourceAdapterDe
             }
          }
       }
-      return list.toArray(new URL[list.size()]);
+      return list.toArray(new URL[0]);
    }
 
    @Override

--- a/deployers/fungal/src/main/java/org/jboss/jca/deployers/fungal/AbstractFungalRADeployer.java
+++ b/deployers/fungal/src/main/java/org/jboss/jca/deployers/fungal/AbstractFungalRADeployer.java
@@ -41,7 +41,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -262,7 +261,7 @@ public abstract class AbstractFungalRADeployer extends AbstractResourceAdapterDe
     */
    protected URL[] getUrls(File directory) throws MalformedURLException, IOException
    {
-      List<URL> list = new LinkedList<URL>();
+      List<URL> list = new ArrayList<URL>();
 
       if (directory.exists() && directory.isDirectory())
       {

--- a/deployers/fungal/src/main/java/org/jboss/jca/deployers/fungal/external/LocalList.java
+++ b/deployers/fungal/src/main/java/org/jboss/jca/deployers/fungal/external/LocalList.java
@@ -71,7 +71,7 @@ public class LocalList implements Command
          if (args != null)
             throw new IllegalArgumentException("Invalid number of arguments");
 
-         return deployments.toArray(new URL[deployments.size()]);
+         return deployments.toArray(new URL[0]);
       }
       catch (Throwable t)
       {

--- a/eclipse/src/main/java/org/jboss/jca/eclipse/command/raui/ResourceAdapterHelper.java
+++ b/eclipse/src/main/java/org/jboss/jca/eclipse/command/raui/ResourceAdapterHelper.java
@@ -99,7 +99,7 @@ public class ResourceAdapterHelper
             }
          }
       }
-      return list.toArray(new URL[list.size()]);
+      return list.toArray(new URL[0]);
    }
    
    /**

--- a/eclipse/src/main/java/org/jboss/jca/eclipse/command/raui/ResourceAdapterHelper.java
+++ b/eclipse/src/main/java/org/jboss/jca/eclipse/command/raui/ResourceAdapterHelper.java
@@ -58,7 +58,6 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -82,7 +81,7 @@ public class ResourceAdapterHelper
     */
    private URL[] getURLs(File directory) throws Exception
    {
-      List<URL> list = new LinkedList<URL>();
+      List<URL> list = new ArrayList<URL>();
 
       if (directory.exists() && directory.isDirectory())
       {

--- a/eclipse/src/main/java/org/jboss/jca/eclipse/wizards/CodeGenWizard.java
+++ b/eclipse/src/main/java/org/jboss/jca/eclipse/wizards/CodeGenWizard.java
@@ -333,7 +333,7 @@ public class CodeGenWizard extends Wizard implements INewWizard
             ijJarName.substring(ijJarName.lastIndexOf("/"))), null, null));
       }
 
-      javaProject.setRawClasspath(entries.toArray(new IClasspathEntry[entries.size()]), progressMonitor);
+      javaProject.setRawClasspath(entries.toArray(new IClasspathEntry[0]), progressMonitor);
 
       monitor.worked(1);
 

--- a/eis/src/main/java/org/jboss/jca/test/eis/maven/Start.java
+++ b/eis/src/main/java/org/jboss/jca/test/eis/maven/Start.java
@@ -87,7 +87,7 @@ public class Start extends EISMojo
                urls.add(f.toURI().toURL());
             }
 
-            cl = SecurityActions.createURLCLassLoader(urls.toArray(new URL[urls.size()]), Start.class.getClassLoader());
+            cl = SecurityActions.createURLCLassLoader(urls.toArray(new URL[0]), Start.class.getClassLoader());
             SecurityActions.setThreadContextClassLoader(cl);
          }
 

--- a/validator/impl/src/main/java/org/jboss/jca/validator/Validation.java
+++ b/validator/impl/src/main/java/org/jboss/jca/validator/Validation.java
@@ -50,7 +50,6 @@ import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.ResourceBundle;
 import java.util.jar.JarEntry;
@@ -596,7 +595,7 @@ public class Validation
     */
    private static URL[] getUrls(File directory) throws MalformedURLException, IOException
    {
-      List<URL> list = new LinkedList<URL>();
+      List<URL> list = new ArrayList<URL>();
 
       if (directory.exists() && directory.isDirectory())
       {

--- a/validator/impl/src/main/java/org/jboss/jca/validator/Validation.java
+++ b/validator/impl/src/main/java/org/jboss/jca/validator/Validation.java
@@ -128,7 +128,7 @@ public class Validation
                if (jar.endsWith(".jar"))
                   listUrl.add(new File(jar).toURI().toURL());
             }
-            allurls = listUrl.toArray(new URL[listUrl.size()]);
+            allurls = listUrl.toArray(new URL[0]);
          }
          else
             allurls = urls;
@@ -625,7 +625,7 @@ public class Validation
             }
          }
       }
-      return list.toArray(new URL[list.size()]);
+      return list.toArray(new URL[0]);
    }
    
    private static boolean validateClassesInPackage(File root)

--- a/validator/impl/src/main/java/org/jboss/jca/validator/Validator.java
+++ b/validator/impl/src/main/java/org/jboss/jca/validator/Validator.java
@@ -24,7 +24,6 @@ package org.jboss.jca.validator;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -136,7 +135,7 @@ public class Validator
             {
                if (result == null)
                {
-                  result = new LinkedList<Failure>();
+                  result = new ArrayList<Failure>();
                }
                result.addAll(failures);
             }

--- a/validator/impl/src/main/java/org/jboss/jca/validator/Validator.java
+++ b/validator/impl/src/main/java/org/jboss/jca/validator/Validator.java
@@ -77,7 +77,7 @@ public class Validator
       List<String> arrayList = new ArrayList<String>();
       arrayList.addAll(Arrays.asList(CLASS_RULES));
       arrayList.addAll(Arrays.asList(OBJECT_RULES)); 
-      allRules = arrayList.toArray(new String[CLASS_RULES.length + OBJECT_RULES.length]);
+      allRules = arrayList.toArray(new String[0]);
    }
 
    /**


### PR DESCRIPTION
`LinkedList` has higher memory overhead (each element is a separately allocated node with two pointers) and poor cache locality compared to `ArrayList`, which stores elements in a contiguous array. For the access patterns in the changed files — append-only lists and LIFO stacks operating at the tail — `ArrayList` provides better performance since all operations are O(1) amortized with no per-element allocation overhead.

`CapacityFiller` and `PoolFiller` are intentionally left unchanged as they use FIFO queue semantics (removeFirst), where `LinkedList`'s O(1) head removal outperforms `ArrayList`'s O(n) array shift.