### PR TITLE
[JBJCA-1435] Fix unreachable code in Annotations.processConnector()

### DIFF
--- a/common/impl/src/main/java/org/jboss/jca/common/annotations/Annotations.java
+++ b/common/impl/src/main/java/org/jboss/jca/common/annotations/Annotations.java
@@ -256,15 +256,6 @@ public class Annotations
             connector = attachConnector(raClass, classLoader, connectorAnnotation, connectionDefinitions,
                                         configProperties, plainConfigProperties, inboundResourceadapter, adminObjs);
          }
-         else if (values.size() == 0)
-         {
-            // JBJCA-240
-            if (xmlResourceAdapterClass == null || xmlResourceAdapterClass.equals(""))
-            {
-               log.noConnector();
-               throw new ValidateException(bundle.noConnectorDefined());
-            }
-         }
          else
          {
             // JBJCA-240
@@ -277,6 +268,12 @@ public class Annotations
       }
       else
       {
+         // JBJCA-240 / JBJCA-1435
+         if (xmlResourceAdapterClass == null || xmlResourceAdapterClass.equals(""))
+         {
+            log.noConnector();
+            throw new ValidateException(bundle.noConnectorDefined());
+         }
          connector = attachConnector(xmlResourceAdapterClass, classLoader, null, connectionDefinitions, null, null,
                                      inboundResourceadapter, adminObjs);
       }

--- a/common/impl/src/test/java/org/jboss/jca/common/annotations/AnnotationsTestCase.java
+++ b/common/impl/src/test/java/org/jboss/jca/common/annotations/AnnotationsTestCase.java
@@ -1,0 +1,58 @@
+/*
+ * IronJacamar, a Java EE Connector Architecture implementation
+ * Copyright 2012, Red Hat Inc, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.jca.common.annotations;
+
+import org.jboss.jca.common.api.validator.ValidateException;
+import org.jboss.jca.common.spi.annotations.repository.Annotation;
+import org.jboss.jca.common.spi.annotations.repository.AnnotationRepository;
+
+import java.util.Collection;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link Annotations}
+ *
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+public class AnnotationsTestCase
+{
+   /**
+    * JBJCA-1435: When no @Connector annotation is found (getAnnotation returns null)
+    * and no xmlResourceAdapterClass is provided, process() should throw ValidateException.
+    */
+   @Test(expected = ValidateException.class)
+   public void testNoConnectorAnnotationShouldThrowValidateException() throws Exception
+   {
+      AnnotationRepository repository = new AnnotationRepository()
+      {
+         @Override
+         public Collection<Annotation> getAnnotation(Class<?> class1)
+         {
+            return null;
+         }
+      };
+
+      Annotations annotations = new Annotations();
+      annotations.process(repository, null, Thread.currentThread().getContextClassLoader());
+   }
+}


### PR DESCRIPTION
- `AnnotationRepository.getAnnotation()` returns `null` (not an empty collection) when no annotations are found. 
- The `values.size() == 0` branch was unreachable because it was guarded by `if (values != null)`. 
- Move the no-connector validation into the `else` (values == null) block so it is actually executed.
- Fixes [JBJCA-1435](https://redhat.atlassian.net/browse/JBJCA-1435)
- Closes https://github.com/ironjacamar/ironjacamar/pull/741