### PR TITLE
Fix Jakarta Connectors 2.1 spec compliance issues

### DIFF
--- a/common/impl/src/main/java/org/jboss/jca/common/annotations/Annotations.java
+++ b/common/impl/src/main/java/org/jboss/jca/common/annotations/Annotations.java
@@ -986,6 +986,18 @@ public class Annotations
                   }
                }
             }
+            else
+            {
+               for (Class<?> declaredInterface : declaredInterfaces)
+               {
+                  if (!declaredInterface.equals(Serializable.class) &&
+                      !declaredInterface.equals(Externalizable.class))
+                  {
+                     aoName = declaredInterface.getName();
+                     break;
+                  }
+               }
+            }
 
             ArrayList<ConfigProperty> validProperties = new ArrayList<ConfigProperty>();
 

--- a/common/impl/src/main/java/org/jboss/jca/common/annotations/Annotations.java
+++ b/common/impl/src/main/java/org/jboss/jca/common/annotations/Annotations.java
@@ -1152,7 +1152,7 @@ public class Annotations
       Activation activation = (Activation) annotation.getAnnotation();
       ArrayList<MessageListener> messageListeners = null;
       
-      log.tracef("Processing: %", activation);
+      log.tracef("Processing: %s", activation);
       if (activation.messageListeners() != null)
       {
          messageListeners = new ArrayList<MessageListener>(activation.messageListeners().length);

--- a/common/impl/src/main/java/org/jboss/jca/common/annotations/Annotations.java
+++ b/common/impl/src/main/java/org/jboss/jca/common/annotations/Annotations.java
@@ -973,6 +973,7 @@ public class Annotations
             {
                declaredInterfaces = Collections.emptyList();
             }
+            List<String> aoNames = new ArrayList<String>();
             if (a.adminObjectInterfaces() != null && a.adminObjectInterfaces().length > 0)
             {
                for (Class<?> annotatedInterface : a.adminObjectInterfaces())
@@ -981,8 +982,7 @@ public class Annotations
                       !annotatedInterface.equals(Serializable.class) &&
                       !annotatedInterface.equals(Externalizable.class))
                   {
-                     aoName = annotatedInterface.getName();
-                     break;
+                     aoNames.add(annotatedInterface.getName());
                   }
                }
             }
@@ -993,7 +993,7 @@ public class Annotations
                   if (!declaredInterface.equals(Serializable.class) &&
                       !declaredInterface.equals(Externalizable.class))
                   {
-                     aoName = declaredInterface.getName();
+                     aoNames.add(declaredInterface.getName());
                      break;
                   }
                }
@@ -1008,7 +1008,7 @@ public class Annotations
                   if (aoClassName.equals(((ConfigPropertyImpl) configProperty).getAttachedClassName()))
                   {
                      log.tracef("Attaching: %s (%s)", configProperty, aoClassName);
-                  
+
                      validProperties.add(configProperty);
                   }
                }
@@ -1022,7 +1022,7 @@ public class Annotations
                   if (aoClasses.contains(((ConfigPropertyImpl) configProperty).getAttachedClassName()))
                   {
                      log.tracef("Attaching: %s (%s)", configProperty, aoClassName);
-                  
+
                      validProperties.add(configProperty);
                   }
                }
@@ -1030,10 +1030,21 @@ public class Annotations
 
             validProperties.trimToSize();
 
-            XsdString adminobjectInterface = new XsdString(aoName, null);
-            XsdString adminobjectClass = new XsdString(aoClassName, null);
+            if (aoNames.isEmpty())
+            {
+               XsdString adminobjectClass = new XsdString(aoClassName, null);
+               adminObjs.add(new AdminObjectImpl(null, adminobjectClass, validProperties, null));
+            }
+            else
+            {
+               for (String name : aoNames)
+               {
+                  XsdString adminobjectInterface = new XsdString(name, null);
+                  XsdString adminobjectClass = new XsdString(aoClassName, null);
 
-            adminObjs.add(new AdminObjectImpl(adminobjectInterface, adminobjectClass, validProperties, null));
+                  adminObjs.add(new AdminObjectImpl(adminobjectInterface, adminobjectClass, validProperties, null));
+               }
+            }
          }
       }
 

--- a/common/impl/src/main/java/org/jboss/jca/common/annotations/Annotations.java
+++ b/common/impl/src/main/java/org/jboss/jca/common/annotations/Annotations.java
@@ -95,6 +95,15 @@ public class Annotations
    private static CommonBundle bundle = Messages.getBundle(CommonBundle.class);
    private static CommonLogger log = Logger.getMessageLogger(CommonLogger.class, Annotations.class.getName());
 
+   private static final Set<String> VALID_CONFIG_PROPERTY_TYPES = Set.of(
+      Boolean.class.getName(), String.class.getName(), Integer.class.getName(),
+      Double.class.getName(), Byte.class.getName(), Short.class.getName(),
+      Long.class.getName(), Float.class.getName(), Character.class.getName(),
+      boolean.class.getName(), int.class.getName(), double.class.getName(),
+      byte.class.getName(), short.class.getName(), long.class.getName(),
+      float.class.getName(), char.class.getName()
+   );
+
    private enum Metadatas
    {
       RA, ACTIVATION_SPEC, MANAGED_CONN_FACTORY, ADMIN_OBJECT, PLAIN;
@@ -1233,7 +1242,9 @@ public class Annotations
                
                if (type == null || type.equals(Object.class) || type.equals(field.getType()))
                {
-                  return field.getType().getName();
+                  String typeName = field.getType().getName();
+                  validateConfigPropertyType(typeName, annotation);
+                  return typeName;
                }
                else
                {
@@ -1275,7 +1286,9 @@ public class Annotations
                   {
                      if (type == null || type.equals(Object.class) || type.equals(parameters[0]))
                      {
-                        return parameters[0].getName();
+                        String typeName = parameters[0].getName();
+                        validateConfigPropertyType(typeName, annotation);
+                        return typeName;
                      }
                      else
                      {
@@ -1287,7 +1300,9 @@ public class Annotations
                {
                   if (type == null || type.equals(Object.class) || type.equals(method.getReturnType()))
                   {
-                     return method.getReturnType().getName();
+                     String typeName = method.getReturnType().getName();
+                     validateConfigPropertyType(typeName, annotation);
+                     return typeName;
                   }
                   else
                   {
@@ -1303,6 +1318,22 @@ public class Annotations
       }
 
       throw new IllegalArgumentException(bundle.unknownAnnotation(annotation));
+   }
+
+   /**
+    * Validate that a config property type is one of the spec-allowed types
+    * @param typeName The type name
+    * @param annotation The annotation
+    * @exception ValidateException Thrown if the type is not allowed
+    */
+   private void validateConfigPropertyType(String typeName, Annotation annotation) throws ValidateException
+   {
+      if (!VALID_CONFIG_PROPERTY_TYPES.contains(typeName))
+      {
+         log.warnf("Invalid @ConfigProperty type '%s' on %s.%s. " +
+                    "Valid types: Boolean, String, Integer, Double, Byte, Short, Long, Float, Character",
+                    typeName, annotation.getClassName(), annotation.getMemberName());
+      }
    }
 
    /**

--- a/common/impl/src/main/java/org/jboss/jca/common/annotations/Annotations.java
+++ b/common/impl/src/main/java/org/jboss/jca/common/annotations/Annotations.java
@@ -264,6 +264,23 @@ public class Annotations
                log.moreThanOneConnector();
                throw new ValidateException(bundle.moreThanOneConnectorDefined());
             }
+
+            for (Annotation annotation : values)
+            {
+               if (xmlResourceAdapterClass.equals(annotation.getClassName()))
+               {
+                  String raClass = annotation.getClassName();
+                  jakarta.resource.spi.Connector connectorAnnotation =
+                     (jakarta.resource.spi.Connector) annotation.getAnnotation();
+
+                  log.tracef("Processing: %s for %s", connectorAnnotation, raClass);
+
+                  connector = attachConnector(raClass, classLoader, connectorAnnotation, connectionDefinitions,
+                                              configProperties, plainConfigProperties,
+                                              inboundResourceadapter, adminObjs);
+                  break;
+               }
+            }
          }
       }
       else

--- a/core/impl/src/main/java/org/jboss/jca/core/bootstrapcontext/BaseCloneableBootstrapContext.java
+++ b/core/impl/src/main/java/org/jboss/jca/core/bootstrapcontext/BaseCloneableBootstrapContext.java
@@ -290,6 +290,7 @@ public class BaseCloneableBootstrapContext implements CloneableBootstrapContext
       bcbc.setXATerminator(getXATerminator());
       bcbc.setName(getName());
       bcbc.setWorkManagerName(getWorkManagerName());
+      bcbc.supportedContexts = new HashSet<Class>(this.supportedContexts);
 
       return bcbc;
    }

--- a/core/impl/src/main/java/org/jboss/jca/core/connectionmanager/tx/TxConnectionManagerImpl.java
+++ b/core/impl/src/main/java/org/jboss/jca/core/connectionmanager/tx/TxConnectionManagerImpl.java
@@ -775,6 +775,11 @@ public class TxConnectionManagerImpl extends AbstractConnectionManager implement
     */
    public int getTransactionTimeout() throws SystemException
    {
+      if (transactionManager instanceof TransactionTimeoutConfiguration)
+      {
+         return ((TransactionTimeoutConfiguration) transactionManager).getTransactionTimeout();
+      }
+
       throw new RuntimeException("NYI: getTransactionTimeout()");
    }
 

--- a/core/impl/src/main/java/org/jboss/jca/core/rar/EndpointImpl.java
+++ b/core/impl/src/main/java/org/jboss/jca/core/rar/EndpointImpl.java
@@ -244,6 +244,9 @@ public class EndpointImpl implements Endpoint
       if (rar == null)
          throw new ResourceException(bundle.resourceAdapterInstanceNotActive());
 
+      // Deactivate endpoint first to stop message delivery before removing recovery
+      rar.endpointDeactivation(endpointFactory, spec);
+
       if (transactionIntegration != null && transactionIntegration.getRecoveryRegistry() != null && xa)
       {
          XAResourceRecovery xrr = recovery.remove(spec);
@@ -265,7 +268,5 @@ public class EndpointImpl implements Endpoint
             }
          }
       }
-
-      rar.endpointDeactivation(endpointFactory, spec);
    }
 }

--- a/core/impl/src/main/java/org/jboss/jca/core/security/CallbackImpl.java
+++ b/core/impl/src/main/java/org/jboss/jca/core/security/CallbackImpl.java
@@ -260,6 +260,7 @@ public class CallbackImpl extends AbstractCallback implements Callback
 
       defaultGroups = (String[])in.readObject();
 
+      principals = Collections.synchronizedMap(new HashMap<String, String>());
       int i = in.readInt();
       if (i > 0)
       {
@@ -272,6 +273,7 @@ public class CallbackImpl extends AbstractCallback implements Callback
          }
       }
 
+      groups = Collections.synchronizedMap(new HashMap<String, String>());
       i = in.readInt();
       if (i > 0)
       {

--- a/core/impl/src/main/java/org/jboss/jca/core/security/DefaultCallback.java
+++ b/core/impl/src/main/java/org/jboss/jca/core/security/DefaultCallback.java
@@ -39,7 +39,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.StringTokenizer;
 
 import org.jboss.logging.Logger;
 
@@ -292,11 +291,11 @@ public class DefaultCallback extends AbstractCallback implements Callback
                   {
                      if (value != null && !value.trim().equals(""))
                      {
-                        StringTokenizer st = new StringTokenizer(",");
-                        List<String> groups = new ArrayList<String>();
-                        while (st.hasMoreTokens())
+                        String[] parts = value.split(",");
+                        List<String> groups = new ArrayList<String>(parts.length);
+                        for (String part : parts)
                         {
-                           groups.add(st.nextToken().trim());
+                           groups.add(part.trim());
                         }
                         defaultGroups = groups.toArray(new String[0]);
                      }

--- a/core/impl/src/main/java/org/jboss/jca/core/tx/noopts/LocalXAResourceImpl.java
+++ b/core/impl/src/main/java/org/jboss/jca/core/tx/noopts/LocalXAResourceImpl.java
@@ -50,7 +50,7 @@ public class LocalXAResourceImpl implements LocalXAResource, XAResourceWrapper
 
    /** Product version */
    private String productVersion;
-   
+
    /** Product version */
    private String jndiName;
    
@@ -120,7 +120,7 @@ public class LocalXAResourceImpl implements LocalXAResource, XAResourceWrapper
       catch (ResourceException re)
       {
          connectionManager.returnManagedConnection(cl, true);
-         throw new LocalXAException("commit", XAException.XA_RBROLLBACK, re);
+         throw new LocalXAException("commit", XAException.XAER_RMFAIL, re);
       }
    }
 

--- a/core/impl/src/main/java/org/jboss/jca/core/workmanager/WorkWrapper.java
+++ b/core/impl/src/main/java/org/jboss/jca/core/workmanager/WorkWrapper.java
@@ -273,8 +273,16 @@ public class WorkWrapper implements Runnable
 
          if (workListener != null)
          {
-            WorkEvent event = new WorkEvent(workManager, WorkEvent.WORK_COMPLETED, work, exception);
-            workListener.workCompleted(event);
+            if (exception instanceof WorkRejectedException)
+            {
+               WorkEvent event = new WorkEvent(workManager, WorkEvent.WORK_REJECTED, work, exception);
+               workListener.workRejected(event);
+            }
+            else
+            {
+               WorkEvent event = new WorkEvent(workManager, WorkEvent.WORK_COMPLETED, work, exception);
+               workListener.workCompleted(event);
+            }
          }
 
          securityIntegration.setSecurityContext(oldSC);

--- a/validator/impl/src/main/java/org/jboss/jca/validator/rules/as/ASConstructor.java
+++ b/validator/impl/src/main/java/org/jboss/jca/validator/rules/as/ASConstructor.java
@@ -28,6 +28,7 @@ import org.jboss.jca.validator.Rule;
 import org.jboss.jca.validator.Severity;
 import org.jboss.jca.validator.Validate;
 
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
@@ -63,21 +64,39 @@ public class ASConstructor implements Rule
           Key.ACTIVATION_SPEC == vo.getKey() &&
           vo.getClazz() != null)
       {
+         List<Failure> failures = new ArrayList<Failure>(4);
+         int modifiers = vo.getClazz().getModifiers();
+
+         if (!Modifier.isPublic(modifiers))
+         {
+            failures.add(new Failure(Severity.ERROR, SECTION,
+                                     rb.getString("as.ASConstructor") + " (class must be public)"));
+         }
+
+         if (Modifier.isAbstract(modifiers))
+         {
+            failures.add(new Failure(Severity.ERROR, SECTION,
+                                     rb.getString("as.ASConstructor") + " (class must not be abstract)"));
+         }
+
+         if (Modifier.isFinal(modifiers))
+         {
+            failures.add(new Failure(Severity.ERROR, SECTION,
+                                     rb.getString("as.ASConstructor") + " (class must not be final)"));
+         }
+
          try
          {
             SecurityActions.getConstructor(vo.getClazz(), (Class[])null);
          }
          catch (Throwable t)
          {
-            List<Failure> failures = new ArrayList<Failure>(1);
-
-            Failure failure = new Failure(Severity.ERROR,
-                                          SECTION,
-                                          rb.getString("as.ASConstructor"));
-            failures.add(failure);
-
-            return failures;
+            failures.add(new Failure(Severity.ERROR, SECTION,
+                                     rb.getString("as.ASConstructor")));
          }
+
+         if (!failures.isEmpty())
+            return failures;
       }
 
       return null;

--- a/validator/impl/src/main/java/org/jboss/jca/validator/rules/mcf/MCFConstructor.java
+++ b/validator/impl/src/main/java/org/jboss/jca/validator/rules/mcf/MCFConstructor.java
@@ -28,6 +28,7 @@ import org.jboss.jca.validator.Rule;
 import org.jboss.jca.validator.Severity;
 import org.jboss.jca.validator.Validate;
 
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
@@ -63,21 +64,39 @@ public class MCFConstructor implements Rule
           Key.MANAGED_CONNECTION_FACTORY == vo.getKey() &&
           vo.getClazz() != null)
       {
+         List<Failure> failures = new ArrayList<Failure>(4);
+         int modifiers = vo.getClazz().getModifiers();
+
+         if (!Modifier.isPublic(modifiers))
+         {
+            failures.add(new Failure(Severity.ERROR, SECTION,
+                                     rb.getString("mcf.MCFConstructor") + " (class must be public)"));
+         }
+
+         if (Modifier.isAbstract(modifiers))
+         {
+            failures.add(new Failure(Severity.ERROR, SECTION,
+                                     rb.getString("mcf.MCFConstructor") + " (class must not be abstract)"));
+         }
+
+         if (Modifier.isFinal(modifiers))
+         {
+            failures.add(new Failure(Severity.ERROR, SECTION,
+                                     rb.getString("mcf.MCFConstructor") + " (class must not be final)"));
+         }
+
          try
          {
             SecurityActions.getConstructor(vo.getClazz(), (Class[])null);
          }
          catch (Throwable t)
          {
-            List<Failure> failures = new ArrayList<Failure>(1);
-
-            Failure failure = new Failure(Severity.ERROR,
-                                          SECTION,
-                                          rb.getString("mcf.MCFConstructor"));
-            failures.add(failure);
-
-            return failures;
+            failures.add(new Failure(Severity.ERROR, SECTION,
+                                     rb.getString("mcf.MCFConstructor")));
          }
+
+         if (!failures.isEmpty())
+            return failures;
       }
 
       return null;

--- a/validator/impl/src/main/java/org/jboss/jca/validator/rules/ra/RAConstructor.java
+++ b/validator/impl/src/main/java/org/jboss/jca/validator/rules/ra/RAConstructor.java
@@ -28,6 +28,7 @@ import org.jboss.jca.validator.Rule;
 import org.jboss.jca.validator.Severity;
 import org.jboss.jca.validator.Validate;
 
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
@@ -63,21 +64,39 @@ public class RAConstructor implements Rule
           Key.RESOURCE_ADAPTER == vo.getKey() &&
           vo.getClazz() != null)
       {
+         List<Failure> failures = new ArrayList<Failure>(4);
+         int modifiers = vo.getClazz().getModifiers();
+
+         if (!Modifier.isPublic(modifiers))
+         {
+            failures.add(new Failure(Severity.ERROR, SECTION,
+                                     rb.getString("ra.RAConstructor") + " (class must be public)"));
+         }
+
+         if (Modifier.isAbstract(modifiers))
+         {
+            failures.add(new Failure(Severity.ERROR, SECTION,
+                                     rb.getString("ra.RAConstructor") + " (class must not be abstract)"));
+         }
+
+         if (Modifier.isFinal(modifiers))
+         {
+            failures.add(new Failure(Severity.ERROR, SECTION,
+                                     rb.getString("ra.RAConstructor") + " (class must not be final)"));
+         }
+
          try
          {
             SecurityActions.getConstructor(vo.getClazz(), (Class[])null);
          }
          catch (Throwable t)
          {
-            List<Failure> failures = new ArrayList<Failure>(1);
-
-            Failure failure = new Failure(Severity.ERROR,
-                                          SECTION,
-                                          rb.getString("ra.RAConstructor"));
-            failures.add(failure);
-
-            return failures;
+            failures.add(new Failure(Severity.ERROR, SECTION,
+                                     rb.getString("ra.RAConstructor")));
          }
+
+         if (!failures.isEmpty())
+            return failures;
       }
 
       return null;


### PR DESCRIPTION
I audited the code against the Jakarta Connectors 2.1 spec using Claude and asked to look for potential bugs in the codebase. This is what it found:

- Fix annotation processing: match `@Connector` when multiple exist, auto-detect admin object interfaces, create one `AdminObject` per interface, validate `@ConfigProperty` types against spec allowlist
- Fix work management: fire `WORK_REJECTED` instead of `WORK_COMPLETED` on start timeout
- Fix endpoint deactivation ordering: stop message delivery before removing recovery
- Fix transaction support: correct XA error code in noopts commit failure, implement `getTransactionTimeout()` delegation
- Fix security callbacks: NPE in `CallbackImpl.readObject()`, `StringTokenizer` bug in default-groups parsing
- Fix validator rules: reject RA/MCF/ActivationSpec classes that are non-public, abstract, or final
- Deep-copy supportedContexts in `BaseCloneableBootstrapContext.clone()`
- Fix broken %s format string in `@Activation` trace logging