### PR TITLE
Bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,20 +22,16 @@ jobs:
         java: ['25']
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+      - uses: actions/checkout@v6
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+          cache: 'maven'
       - name: Build and Test on ${{ matrix.java }}
         run: mvn clean install --fail-at-end
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: surefire-reports-${{ matrix.os }}-${{ matrix.java }}


### PR DESCRIPTION
- `actions/checkout`: v2 → v6
- `actions/setup-java`: v1 → v5 (adds built-in Maven caching)
- `actions/upload-artifact`: v4 → v7
- Remove standalone `actions/cache` in favor of `setup-java` cache
