### PR TITLE
[JBJCA-1435] Fix `processConnector()` to handle RARs without `@Connector`

### DIFF
--- a/common/impl/src/main/java/org/jboss/jca/common/annotations/Annotations.java
+++ b/common/impl/src/main/java/org/jboss/jca/common/annotations/Annotations.java
@@ -268,12 +268,6 @@ public class Annotations
       }
       else
       {
-         // JBJCA-240 / JBJCA-1435
-         if (xmlResourceAdapterClass == null || xmlResourceAdapterClass.equals(""))
-         {
-            log.noConnector();
-            throw new ValidateException(bundle.noConnectorDefined());
-         }
          connector = attachConnector(xmlResourceAdapterClass, classLoader, null, connectionDefinitions, null, null,
                                      inboundResourceadapter, adminObjs);
       }

--- a/common/impl/src/test/java/org/jboss/jca/common/annotations/AnnotationsTestCase.java
+++ b/common/impl/src/test/java/org/jboss/jca/common/annotations/AnnotationsTestCase.java
@@ -21,13 +21,16 @@
  */
 package org.jboss.jca.common.annotations;
 
-import org.jboss.jca.common.api.validator.ValidateException;
+import org.jboss.jca.common.api.metadata.spec.Connector;
 import org.jboss.jca.common.spi.annotations.repository.Annotation;
 import org.jboss.jca.common.spi.annotations.repository.AnnotationRepository;
 
 import java.util.Collection;
 
 import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests for {@link Annotations}
@@ -38,10 +41,11 @@ public class AnnotationsTestCase
 {
    /**
     * JBJCA-1435: When no @Connector annotation is found (getAnnotation returns null)
-    * and no xmlResourceAdapterClass is provided, process() should throw ValidateException.
+    * and no xmlResourceAdapterClass is provided, process() should return a connector
+    * with no resource adapter class.
     */
-   @Test(expected = ValidateException.class)
-   public void testNoConnectorAnnotationShouldThrowValidateException() throws Exception
+   @Test
+   public void testNoConnectorAnnotationShouldReturnConnectorWithNoRAClass() throws Exception
    {
       AnnotationRepository repository = new AnnotationRepository()
       {
@@ -53,6 +57,8 @@ public class AnnotationsTestCase
       };
 
       Annotations annotations = new Annotations();
-      annotations.process(repository, null, Thread.currentThread().getContextClassLoader());
+      Connector result = annotations.process(repository, null, Thread.currentThread().getContextClassLoader());
+      assertNotNull(result);
+      assertNull(result.getResourceadapter().getResourceadapterClass());
    }
 }


### PR DESCRIPTION
The JBJCA-1435 fix moved the no-connector validation into the `values == null` branch but threw unconditionally when no `xmlResourceAdapterClass` was provided. This broke RARs that use `@ConnectionDefinitions` or `@AdministeredObject` without `@Connector`.

Restore the original behavior: when no `@Connector` annotation is found, build a connector from the remaining annotations (connection definitions, admin objects, etc.) with a null resource adapter class.

- Follow-up from https://github.com/ironjacamar/ironjacamar/pull/1028