### PR TITLE
Set asciidoctor-maven-plugin version in pluginManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -565,6 +565,11 @@
                         </annotationProcessorPaths>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.asciidoctor</groupId>
+                    <artifactId>asciidoctor-maven-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
This gets rid of the build warning:

```java
  [WARNING] Some problems were encountered while building the effective model for org.jboss.ironjacamar:ironjacamar-docs:jar:3.0.20.Final-SNAPSHOT
  [WARNING] 'build.plugins.plugin.version' for org.asciidoctor:asciidoctor-maven-plugin is missing. @ line 48, column 21
  [WARNING]
  [WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
  [WARNING]
  [WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```

