### PR TITLE
Skip @AdministeredObject when class does not implement declared interfaces

### DIFF
--- a/common/impl/src/main/java/org/jboss/jca/common/annotations/Annotations.java
+++ b/common/impl/src/main/java/org/jboss/jca/common/annotations/Annotations.java
@@ -988,6 +988,9 @@ public class Annotations
                      aoNames.add(annotatedInterface.getName());
                   }
                }
+
+               if (aoNames.isEmpty())
+                  continue;
             }
             else
             {


### PR DESCRIPTION
## Summary

- Fix regression introduced by 469a84499 where `processAdministeredObject()` creates `AdminObject` entries with null interfaces for classes annotated with `@AdministeredObject(adminObjectInterfaces = X.class)` that don't actually implement `X`
- Before 469a84499 these bogus entries were harmless (discarded because `processConnector()` returned null for multi-`@Connector` RARs); after that commit the connector is properly built and the invalid admin objects get merged in, causing silent deployment failure
- Fix: skip the class entirely when explicitly declared `adminObjectInterfaces` are not implemented — the no-arg `@AdministeredObject` path is unchanged

## Test plan

- [x] `Ra16inoutmultiannoTestCase.testBasic` passes (was failing before fix)
- [x] Full `deployers/tests` suite passes (126 tests, 0 failures)
- [x] `common/impl` tests pass (39 tests, 0 failures)