### PR TITLE
[JBJCA-1539] Change final class validation from ERROR to WARNING

### DIFF
--- a/validator/impl/src/main/java/org/jboss/jca/validator/rules/as/ASConstructor.java
+++ b/validator/impl/src/main/java/org/jboss/jca/validator/rules/as/ASConstructor.java
@@ -81,7 +81,7 @@ public class ASConstructor implements Rule
 
          if (Modifier.isFinal(modifiers))
          {
-            failures.add(new Failure(Severity.ERROR, SECTION,
+            failures.add(new Failure(Severity.WARNING, SECTION,
                                      rb.getString("as.ASConstructor") + " (class must not be final)"));
          }
 

--- a/validator/impl/src/main/java/org/jboss/jca/validator/rules/mcf/MCFConstructor.java
+++ b/validator/impl/src/main/java/org/jboss/jca/validator/rules/mcf/MCFConstructor.java
@@ -81,7 +81,7 @@ public class MCFConstructor implements Rule
 
          if (Modifier.isFinal(modifiers))
          {
-            failures.add(new Failure(Severity.ERROR, SECTION,
+            failures.add(new Failure(Severity.WARNING, SECTION,
                                      rb.getString("mcf.MCFConstructor") + " (class must not be final)"));
          }
 

--- a/validator/impl/src/main/java/org/jboss/jca/validator/rules/ra/RAConstructor.java
+++ b/validator/impl/src/main/java/org/jboss/jca/validator/rules/ra/RAConstructor.java
@@ -81,7 +81,7 @@ public class RAConstructor implements Rule
 
          if (Modifier.isFinal(modifiers))
          {
-            failures.add(new Failure(Severity.ERROR, SECTION,
+            failures.add(new Failure(Severity.WARNING, SECTION,
                                      rb.getString("ra.RAConstructor") + " (class must not be final)"));
          }
 


### PR DESCRIPTION
While JCA spec section 19.3 requires ResourceAdapter, ManagedConnectionFactory, and ActivationSpec classes to be non-final, many existing libraries (e.g. ActiveMQ) violate this requirement. Keeping this as ERROR severity causes deployment failures across the ecosystem. Changed to WARNING to report the issue without breaking deployments, allowing non-compliant but functional resource adapters to continue working.