### PR TITLE
Remove redundant jboss-logging-processor dependency

### DIFF
--- a/common/impl/pom.xml
+++ b/common/impl/pom.xml
@@ -77,10 +77,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
         </dependency>

--- a/core/impl/pom.xml
+++ b/core/impl/pom.xml
@@ -83,10 +83,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.threads</groupId>
             <artifactId>jboss-threads</artifactId>
         </dependency>


### PR DESCRIPTION
## Summary

- Remove the explicit `org.jboss.logging:jboss-logging-processor` dependency from `common/impl/pom.xml` and `core/impl/pom.xml`

## Motivation

The `jboss-logging-processor` is an annotation processor used at compile time to generate logging message bundle implementations from `@MessageLogger`/`@Message` annotations. It is **not** needed at runtime — no source code in the project imports from `org.jboss.logging.processor`.

The parent POM already configures it in `maven-compiler-plugin`'s `annotationProcessorPaths`, which is the correct and sufficient way to provide annotation processors to the compiler. When `annotationProcessorPaths` is specified, Maven uses **only** those paths for annotation processing and ignores the classpath.

The explicit dependency declarations (with default `compile` scope) were therefore redundant for annotation processing and caused the processor JAR to leak as a **transitive compile-scoped dependency** to downstream consumers of `ironjacamar-common-impl` and `ironjacamar-core-impl`.

## Test plan

- [x] `mvn clean install -DskipTests` builds successfully